### PR TITLE
[RFC] Test more @inline options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,4 +9,6 @@ libraryDependencies ++= Seq(
   // "group" % "artifact" % "version"
 )
 
+scalacOptions := Seq("-optimise")
+
 enablePlugins(JmhPlugin)

--- a/jad_scala_2_11_8/AnyValTest.java
+++ b/jad_scala_2_11_8/AnyValTest.java
@@ -1,0 +1,28 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Without
+
+public class AnyValTest
+{
+
+    public Without testWithout()
+    {
+        return new Without(42);
+    }
+
+    public int testWithit()
+    {
+        return 42;
+    }
+
+    public AnyValTest()
+    {
+    }
+}

--- a/jad_scala_2_11_8/BitOpsTest.java
+++ b/jad_scala_2_11_8/BitOpsTest.java
@@ -1,0 +1,136 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   BitOpsTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.BitReader;
+import scala.Serializable;
+import scala.collection.immutable.*;
+import scala.package$;
+import scala.runtime.BoxesRunTime;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class BitOpsTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public IndexedSeq testRead()
+    {
+        BitReader r = new BitReader(encoded());
+        return (IndexedSeq)package$.MODULE$.Range().apply(0, 50).map(new Serializable(r) {
+
+            public final int apply(int x$1)
+            {
+                return r$1.readBits(4);
+            }
+
+            public int apply$mcII$sp(int x$1)
+            {
+                return r$1.readBits(4);
+            }
+
+            public final volatile Object apply(Object v1)
+            {
+                return BoxesRunTime.boxToInteger(apply(BoxesRunTime.unboxToInt(v1)));
+            }
+
+            public static final long serialVersionUID = 0L;
+            public final BitReader r$1;
+
+            public 
+            {
+                this.r$1 = r$1;
+                super();
+            }
+        }
+, IndexedSeq$.MODULE$.canBuildFrom());
+    }
+
+    public BitOpsTest()
+    {
+        EncodingTestData.class.$init$(this);
+    }
+
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_11_8/Centis$.java
+++ b/jad_scala_2_11_8/Centis$.java
@@ -1,0 +1,127 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.collection.Iterator;
+import scala.runtime.*;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Centis
+
+public final class Centis$ extends AbstractFunction1
+    implements Serializable
+{
+
+    public final String toString()
+    {
+        return "Centis";
+    }
+
+    public int apply(int cs)
+    {
+        return cs;
+    }
+
+    public Option unapply(int x$0)
+    {
+        new Centis(x$0);
+        return new Some(BoxesRunTime.boxToInteger(x$0));
+    }
+
+    private Object readResolve()
+    {
+        return MODULE$;
+    }
+
+    public final int copy$extension(int $this, int cs)
+    {
+        return cs;
+    }
+
+    public final int copy$default$1$extension(int $this)
+    {
+        return $this;
+    }
+
+    public final String productPrefix$extension(int $this)
+    {
+        return "Centis";
+    }
+
+    public final int productArity$extension(int $this)
+    {
+        return 1;
+    }
+
+    public final Object productElement$extension(int $this, int x$1)
+    {
+        switch(x$1)
+        {
+        default:
+            throw new IndexOutOfBoundsException(BoxesRunTime.boxToInteger(x$1).toString());
+
+        case 0: // '\0'
+            return BoxesRunTime.boxToInteger($this);
+        }
+    }
+
+    public final Iterator productIterator$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$.typedProductIterator(new Centis($this));
+    }
+
+    public final boolean canEqual$extension(int $this, Object x$1)
+    {
+        return x$1 instanceof Integer;
+    }
+
+    public final int hashCode$extension(int $this)
+    {
+        return BoxesRunTime.boxToInteger($this).hashCode();
+    }
+
+    public final boolean equals$extension(int $this, Object x$1)
+    {
+        boolean flag;
+        if(x$1 instanceof Centis)
+            flag = true;
+        else
+            flag = false;
+        if(!flag) goto _L2; else goto _L1
+_L1:
+        int i = ((Centis)x$1).cs();
+        if($this != i) goto _L2; else goto _L3
+_L3:
+        true;
+          goto _L4
+_L2:
+        false;
+_L4:
+        return;
+    }
+
+    public final String toString$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$._toString(new Centis($this));
+    }
+
+    public volatile Object apply(Object v1)
+    {
+        return new Centis(apply(BoxesRunTime.unboxToInt(v1)));
+    }
+
+    private Centis$()
+    {
+    }
+
+    public static final Centis$ MODULE$ = this;
+
+    static 
+    {
+        new Centis$();
+    }
+}

--- a/jad_scala_2_11_8/Centis.java
+++ b/jad_scala_2_11_8/Centis.java
@@ -1,0 +1,151 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.collection.Iterator;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Centis$
+
+public final class Centis
+    implements Product, Serializable
+{
+
+    public static String toString$extension(int i)
+    {
+        return Centis$.MODULE$.toString$extension(i);
+    }
+
+    public static boolean equals$extension(int i, Object obj)
+    {
+        return Centis$.MODULE$.equals$extension(i, obj);
+    }
+
+    public static int hashCode$extension(int i)
+    {
+        return Centis$.MODULE$.hashCode$extension(i);
+    }
+
+    public static boolean canEqual$extension(int i, Object obj)
+    {
+        return Centis$.MODULE$.canEqual$extension(i, obj);
+    }
+
+    public static Iterator productIterator$extension(int i)
+    {
+        return Centis$.MODULE$.productIterator$extension(i);
+    }
+
+    public static Object productElement$extension(int i, int j)
+    {
+        return Centis$.MODULE$.productElement$extension(i, j);
+    }
+
+    public static int productArity$extension(int i)
+    {
+        return Centis$.MODULE$.productArity$extension(i);
+    }
+
+    public static String productPrefix$extension(int i)
+    {
+        return Centis$.MODULE$.productPrefix$extension(i);
+    }
+
+    public static int copy$default$1$extension(int i)
+    {
+        return Centis$.MODULE$.copy$default$1$extension(i);
+    }
+
+    public static int copy$extension(int i, int j)
+    {
+        return Centis$.MODULE$.copy$extension(i, j);
+    }
+
+    public static Option unapply(int i)
+    {
+        return Centis$.MODULE$.unapply(i);
+    }
+
+    public static int apply(int i)
+    {
+        return Centis$.MODULE$.apply(i);
+    }
+
+    public static Function1 andThen(Function1 function1)
+    {
+        return Centis$.MODULE$.andThen(function1);
+    }
+
+    public static Function1 compose(Function1 function1)
+    {
+        return Centis$.MODULE$.compose(function1);
+    }
+
+    public int cs()
+    {
+        return cs;
+    }
+
+    public int copy(int cs)
+    {
+        return Centis$.MODULE$.copy$extension(cs(), cs);
+    }
+
+    public int copy$default$1()
+    {
+        return Centis$.MODULE$.copy$default$1$extension(cs());
+    }
+
+    public String productPrefix()
+    {
+        return Centis$.MODULE$.productPrefix$extension(cs());
+    }
+
+    public int productArity()
+    {
+        return Centis$.MODULE$.productArity$extension(cs());
+    }
+
+    public Object productElement(int x$1)
+    {
+        return Centis$.MODULE$.productElement$extension(cs(), x$1);
+    }
+
+    public Iterator productIterator()
+    {
+        return Centis$.MODULE$.productIterator$extension(cs());
+    }
+
+    public boolean canEqual(Object x$1)
+    {
+        return Centis$.MODULE$.canEqual$extension(cs(), x$1);
+    }
+
+    public int hashCode()
+    {
+        return Centis$.MODULE$.hashCode$extension(cs());
+    }
+
+    public boolean equals(Object x$1)
+    {
+        return Centis$.MODULE$.equals$extension(cs(), x$1);
+    }
+
+    public String toString()
+    {
+        return Centis$.MODULE$.toString$extension(cs());
+    }
+
+    public Centis(int cs)
+    {
+        this.cs = cs;
+        super();
+        scala.Product.class.$init$(this);
+    }
+
+    private final int cs;
+}

--- a/jad_scala_2_11_8/DurationConvertTest.java
+++ b/jad_scala_2_11_8/DurationConvertTest.java
@@ -1,0 +1,134 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Array$;
+import scala.Serializable;
+import scala.collection.TraversableOnce;
+import scala.collection.immutable.IndexedSeq$;
+import scala.collection.immutable.Range;
+import scala.collection.immutable.Range$;
+import scala.collection.immutable.Vector;
+import scala.collection.immutable.Vector$;
+import scala.collection.package$;
+import scala.concurrent.duration.FiniteDuration;
+import scala.concurrent.duration.package;
+import scala.reflect.ClassTag$;
+import scala.runtime.AbstractFunction1;
+import scala.runtime.BoxesRunTime;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Centis$, Centis, implicits$, implicits
+
+public class DurationConvertTest
+{
+
+    public Vector data()
+    {
+        return data;
+    }
+
+    public Vector centiData()
+    {
+        return centiData;
+    }
+
+    public Vector intCentiData()
+    {
+        return intCentiData;
+    }
+
+    public int[] intToArray()
+    {
+        return (int[])intCentiData().toArray(ClassTag$.MODULE$.Int());
+    }
+
+    public int[] centiBreakout()
+    {
+        return (int[])centiData().map(new Serializable() {
+
+            public final int apply(int x$2)
+            {
+                return x$2;
+            }
+
+            public final volatile Object apply(Object v1)
+            {
+                return BoxesRunTime.boxToInteger(apply(((Centis)v1).cs()));
+            }
+
+            public static final long serialVersionUID = 0L;
+
+        }
+, package$.MODULE$.breakOut(Array$.MODULE$.canBuildFrom(ClassTag$.MODULE$.Int())));
+    }
+
+    public int[] testToMillis()
+    {
+        return (int[])((TraversableOnce)data().map(new Serializable() {
+
+            public final int apply(FiniteDuration x$3)
+            {
+                return (int)x$3.toMillis();
+            }
+
+            public final volatile Object apply(Object v1)
+            {
+                return BoxesRunTime.boxToInteger(apply((FiniteDuration)v1));
+            }
+
+            public static final long serialVersionUID = 0L;
+
+        }
+, Vector$.MODULE$.canBuildFrom())).toArray(ClassTag$.MODULE$.Int());
+    }
+
+    public int[] testToHundredths()
+    {
+        return (int[])((TraversableOnce)data().map(new Serializable() {
+
+            public final int apply(FiniteDuration x$4)
+            {
+                return (int)implicits.LilaPimpedFiniteDuration..MODULE$.toHundredths$extension(implicits$.MODULE$.LilaPimpedFiniteDuration(x$4));
+            }
+
+            public final volatile Object apply(Object v1)
+            {
+                return BoxesRunTime.boxToInteger(apply((FiniteDuration)v1));
+            }
+
+            public static final long serialVersionUID = 0L;
+
+        }
+, Vector$.MODULE$.canBuildFrom())).toArray(ClassTag$.MODULE$.Int());
+    }
+
+    public DurationConvertTest()
+    {
+        data = ((TraversableOnce)scala.package$.MODULE$.Range().apply(0, 30).map(new Serializable() {
+
+            public final FiniteDuration apply(int x$1)
+            {
+                return (new scala.concurrent.duration.package.DurationInt(scala.concurrent.duration.package$.MODULE$.DurationInt(x$1))).millis();
+            }
+
+            public final volatile Object apply(Object v1)
+            {
+                return apply(BoxesRunTime.unboxToInt(v1));
+            }
+
+            public static final long serialVersionUID = 0L;
+
+        }
+, IndexedSeq$.MODULE$.canBuildFrom())).toVector();
+        centiData = ((TraversableOnce)scala.package$.MODULE$.Range().apply(0, 30).map(Centis$.MODULE$, IndexedSeq$.MODULE$.canBuildFrom())).toVector();
+        intCentiData = scala.package$.MODULE$.Range().apply(0, 30).toVector();
+    }
+
+    private final Vector data;
+    private final Vector centiData;
+    private final Vector intCentiData;
+}

--- a/jad_scala_2_11_8/EncodingTestData.java
+++ b/jad_scala_2_11_8/EncodingTestData.java
@@ -1,0 +1,82 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   EncodingTestData.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Serializable;
+import scala.runtime.BoxesRunTime;
+import scala.util.Random;
+
+public interface EncodingTestData
+{
+
+    public abstract void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random random);
+
+    public abstract void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int i);
+
+    public abstract void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int ai[]);
+
+    public abstract void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int i);
+
+    public abstract void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int ai[]);
+
+    public abstract void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int ai[]);
+
+    public abstract void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte abyte0[]);
+
+    public abstract Random org$openjdk$jmh$samples$EncodingTestData$$r();
+
+    public abstract int startTime();
+
+    public abstract int[] centis();
+
+    public abstract int moves();
+
+    public abstract int[] trunced();
+
+    public abstract int[] encodedRounds();
+
+    public abstract byte[] encoded();
+
+    // Unreferenced inner class org/openjdk/jmh/samples/EncodingTestData$$anonfun$1
+
+/* anonymous class */
+    public final class .anonfun._cls1 extends scala.runtime.AbstractFunction1.mcII.sp
+        implements Serializable
+    {
+
+        public final int apply(int x$1)
+        {
+            return apply$mcII$sp(x$1);
+        }
+
+        public int apply$mcII$sp(int x$1)
+        {
+            return (int)((double)x$1 + $outer.org$openjdk$jmh$samples$EncodingTestData$$r().nextGaussian() * (double)500);
+        }
+
+        public final volatile Object apply(Object v1)
+        {
+            return BoxesRunTime.boxToInteger(apply(BoxesRunTime.unboxToInt(v1)));
+        }
+
+        public static final long serialVersionUID = 0L;
+        private final EncodingTestData $outer;
+
+            public 
+            {
+                if(EncodingTestData.this == null)
+                {
+                    throw null;
+                } else
+                {
+                    this.$outer = EncodingTestData.this;
+                    super();
+                    return;
+                }
+            }
+    }
+
+}

--- a/jad_scala_2_11_8/ImplicitClassTest.java
+++ b/jad_scala_2_11_8/ImplicitClassTest.java
@@ -1,0 +1,84 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+import scala.Option$;
+import scala.runtime.BoxesRunTime;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitClasses$, implicitFunctions$, implicitClasses, implicitFunctions
+
+public class ImplicitClassTest
+{
+
+    public Option option()
+    {
+        return option;
+    }
+
+    public boolean testClassStandard()
+    {
+        return implicitClasses$.MODULE$.ImplicitStandard(option()).bar();
+    }
+
+    public boolean testClassAnyVal()
+    {
+        return implicitClasses.ImplicitAnyVal..MODULE$.bar$extension(implicitClasses$.MODULE$.ImplicitAnyVal(option()));
+    }
+
+    public boolean testClassInlineBothAnyVal()
+    {
+        Option option1 = option();
+        implicitClasses$ implicitclasses$ = implicitClasses$.MODULE$;
+        implicitClasses.ImplicitInlineBothAnyVal. 1 = implicitClasses.ImplicitInlineBothAnyVal..MODULE$;
+        return option1.isDefined();
+    }
+
+    public boolean testClassImplicitInlineFunAnyVal()
+    {
+        Option option1 = implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(option());
+        implicitClasses.ImplicitInlineFunAnyVal. 1 = implicitClasses.ImplicitInlineFunAnyVal..MODULE$;
+        return option1.isDefined();
+    }
+
+    public boolean testClassImplicitInlineClassAnyVal()
+    {
+        Option option1 = option();
+        implicitClasses$ implicitclasses$ = implicitClasses$.MODULE$;
+        return implicitClasses.ImplicitInlineClassAnyVal..MODULE$.bar$extension(option1);
+    }
+
+    public boolean testFunctionStandard()
+    {
+        return implicitFunctions$.MODULE$.toStandard(option()).bar();
+    }
+
+    public boolean testFunctionAnyVal()
+    {
+        return implicitFunctions.ImplicitAnyVal..MODULE$.bar$extension(implicitFunctions$.MODULE$.toAnyVal(option()));
+    }
+
+    public boolean testFunctionInlineAnyVal()
+    {
+        Option option1 = option();
+        implicitFunctions$ implicitfunctions$ = implicitFunctions$.MODULE$;
+        implicitFunctions.ImplicitInlineAnyVal. 1 = implicitFunctions.ImplicitInlineAnyVal..MODULE$;
+        return option1.isDefined();
+    }
+
+    public boolean baseline()
+    {
+        return option().isDefined();
+    }
+
+    public ImplicitClassTest()
+    {
+        option = Option$.MODULE$.apply(BoxesRunTime.boxToInteger(42));
+    }
+
+    private final Option option;
+}

--- a/jad_scala_2_11_8/ImplicitClassTest.java
+++ b/jad_scala_2_11_8/ImplicitClassTest.java
@@ -5,9 +5,6 @@
 
 package org.openjdk.jmh.samples;
 
-import scala.Option;
-import scala.Option$;
-import scala.runtime.BoxesRunTime;
 
 // Referenced classes of package org.openjdk.jmh.samples:
 //            implicitClasses$, implicitFunctions$, implicitClasses, implicitFunctions
@@ -15,70 +12,69 @@ import scala.runtime.BoxesRunTime;
 public class ImplicitClassTest
 {
 
-    public Option option()
+    public int option()
     {
         return option;
     }
 
-    public boolean testClassStandard()
+    public int testClassStandard()
     {
         return implicitClasses$.MODULE$.ImplicitStandard(option()).bar();
     }
 
-    public boolean testClassAnyVal()
+    public int testClassAnyVal()
     {
         return implicitClasses.ImplicitAnyVal..MODULE$.bar$extension(implicitClasses$.MODULE$.ImplicitAnyVal(option()));
     }
 
-    public boolean testClassInlineBothAnyVal()
+    public int testClassInlineBothAnyVal()
     {
-        Option option1 = option();
+        int i = option();
         implicitClasses$ implicitclasses$ = implicitClasses$.MODULE$;
         implicitClasses.ImplicitInlineBothAnyVal. 1 = implicitClasses.ImplicitInlineBothAnyVal..MODULE$;
-        return option1.isDefined();
+        return i + 2;
     }
 
-    public boolean testClassImplicitInlineFunAnyVal()
+    public int testClassImplicitInlineFunAnyVal()
     {
-        Option option1 = implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(option());
+        int i = implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(option());
         implicitClasses.ImplicitInlineFunAnyVal. 1 = implicitClasses.ImplicitInlineFunAnyVal..MODULE$;
-        return option1.isDefined();
+        return i + 2;
     }
 
-    public boolean testClassImplicitInlineClassAnyVal()
+    public int testClassImplicitInlineClassAnyVal()
     {
-        Option option1 = option();
+        int i = option();
         implicitClasses$ implicitclasses$ = implicitClasses$.MODULE$;
-        return implicitClasses.ImplicitInlineClassAnyVal..MODULE$.bar$extension(option1);
+        return implicitClasses.ImplicitInlineClassAnyVal..MODULE$.bar$extension(i);
     }
 
-    public boolean testFunctionStandard()
+    public int testFunctionStandard()
     {
         return implicitFunctions$.MODULE$.toStandard(option()).bar();
     }
 
-    public boolean testFunctionAnyVal()
+    public int testFunctionAnyVal()
     {
         return implicitFunctions.ImplicitAnyVal..MODULE$.bar$extension(implicitFunctions$.MODULE$.toAnyVal(option()));
     }
 
-    public boolean testFunctionInlineAnyVal()
+    public int testFunctionInlineAnyVal()
     {
-        Option option1 = option();
+        int i = option();
         implicitFunctions$ implicitfunctions$ = implicitFunctions$.MODULE$;
         implicitFunctions.ImplicitInlineAnyVal. 1 = implicitFunctions.ImplicitInlineAnyVal..MODULE$;
-        return option1.isDefined();
+        return i + 2;
     }
 
-    public boolean baseline()
+    public int baseline()
     {
-        return option().isDefined();
+        return option() + 2;
     }
 
     public ImplicitClassTest()
     {
-        option = Option$.MODULE$.apply(BoxesRunTime.boxToInteger(42));
     }
 
-    private final Option option;
+    private final int option = 42;
 }

--- a/jad_scala_2_11_8/LinearEstimateTest.java
+++ b/jad_scala_2_11_8/LinearEstimateTest.java
@@ -1,0 +1,105 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   LinearEstimateTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.LinearEstimator;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class LinearEstimateTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public void testEncode()
+    {
+        LinearEstimator.encode(trunced(), startTime());
+    }
+
+    public LinearEstimateTest()
+    {
+        EncodingTestData.class.$init$(this);
+    }
+
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_11_8/LowBitTruncTest.java
+++ b/jad_scala_2_11_8/LowBitTruncTest.java
@@ -1,0 +1,111 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   LowBitTruncTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.LowBitTruncator;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class LowBitTruncTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public int[] testData()
+    {
+        return testData;
+    }
+
+    public void testEncode()
+    {
+        LowBitTruncator.truncate(testData());
+    }
+
+    public LowBitTruncTest()
+    {
+        EncodingTestData.class.$init$(this);
+    }
+
+    private final int testData[] = (int[])centis().clone();
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_11_8/NullTest.java
+++ b/jad_scala_2_11_8/NullTest.java
@@ -1,0 +1,94 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   NullTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+import scala.Option$;
+
+public class NullTest
+{
+    public class Foo
+    {
+
+        public NullTest org$openjdk$jmh$samples$NullTest$Foo$$$outer()
+        {
+            return $outer;
+        }
+
+        public final NullTest $outer;
+
+        public Foo()
+        {
+            if(NullTest.this == null)
+            {
+                throw null;
+            } else
+            {
+                this.$outer = NullTest.this;
+                super();
+                return;
+            }
+        }
+    }
+
+
+    public Foo a()
+    {
+        return a;
+    }
+
+    public Foo b()
+    {
+        return b;
+    }
+
+    public boolean isNotNull(Object x)
+    {
+        return x != null;
+    }
+
+    public boolean isNotNullInline(Object x)
+    {
+        return x != null;
+    }
+
+    public boolean testNullWithOption()
+    {
+        return Option$.MODULE$.apply(a()).isDefined();
+    }
+
+    public boolean testDefinedWithOption()
+    {
+        return Option$.MODULE$.apply(b()).isDefined();
+    }
+
+    public boolean testNullWithFunction()
+    {
+        return isNotNull(a());
+    }
+
+    public boolean testDefinedWithFunction()
+    {
+        return isNotNull(b());
+    }
+
+    public boolean testNullWithFunctionInline()
+    {
+        return isNotNullInline(a());
+    }
+
+    public boolean testDefinedWithFunctionInline()
+    {
+        return isNotNullInline(b());
+    }
+
+    public NullTest()
+    {
+    }
+
+    private final Foo a = null;
+    private final Foo b = new Foo();
+}

--- a/jad_scala_2_11_8/OverallEncodingTest.java
+++ b/jad_scala_2_11_8/OverallEncodingTest.java
@@ -1,0 +1,110 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   OverallEncodingTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.Encoder;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class OverallEncodingTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public byte[] testEncode()
+    {
+        return Encoder.encode(centis(), startTime());
+    }
+
+    public int[] testDecode()
+    {
+        return Encoder.decode(encoded(), moves(), startTime());
+    }
+
+    public OverallEncodingTest()
+    {
+        EncodingTestData.class.$init$(this);
+    }
+
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_11_8/VarIntEncodingTest.java
+++ b/jad_scala_2_11_8/VarIntEncodingTest.java
@@ -1,0 +1,112 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   VarIntEncodingTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.*;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class VarIntEncodingTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public byte[] testEncode()
+    {
+        BitWriter writer = new BitWriter();
+        VarIntEncoder.write(encodedRounds(), writer);
+        return writer.toArray();
+    }
+
+    public int[] testDecode()
+    {
+        return VarIntEncoder.read(new BitReader(encoded()), moves());
+    }
+
+    public VarIntEncodingTest()
+    {
+        EncodingTestData.class.$init$(this);
+    }
+
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_11_8/Withit$.java
+++ b/jad_scala_2_11_8/Withit$.java
@@ -1,0 +1,127 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.collection.Iterator;
+import scala.runtime.*;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Withit
+
+public final class Withit$ extends AbstractFunction1
+    implements Serializable
+{
+
+    public final String toString()
+    {
+        return "Withit";
+    }
+
+    public int apply(int value)
+    {
+        return value;
+    }
+
+    public Option unapply(int x$0)
+    {
+        new Withit(x$0);
+        return new Some(BoxesRunTime.boxToInteger(x$0));
+    }
+
+    private Object readResolve()
+    {
+        return MODULE$;
+    }
+
+    public final int copy$extension(int $this, int value)
+    {
+        return value;
+    }
+
+    public final int copy$default$1$extension(int $this)
+    {
+        return $this;
+    }
+
+    public final String productPrefix$extension(int $this)
+    {
+        return "Withit";
+    }
+
+    public final int productArity$extension(int $this)
+    {
+        return 1;
+    }
+
+    public final Object productElement$extension(int $this, int x$1)
+    {
+        switch(x$1)
+        {
+        default:
+            throw new IndexOutOfBoundsException(BoxesRunTime.boxToInteger(x$1).toString());
+
+        case 0: // '\0'
+            return BoxesRunTime.boxToInteger($this);
+        }
+    }
+
+    public final Iterator productIterator$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$.typedProductIterator(new Withit($this));
+    }
+
+    public final boolean canEqual$extension(int $this, Object x$1)
+    {
+        return x$1 instanceof Integer;
+    }
+
+    public final int hashCode$extension(int $this)
+    {
+        return BoxesRunTime.boxToInteger($this).hashCode();
+    }
+
+    public final boolean equals$extension(int $this, Object x$1)
+    {
+        boolean flag;
+        if(x$1 instanceof Withit)
+            flag = true;
+        else
+            flag = false;
+        if(!flag) goto _L2; else goto _L1
+_L1:
+        int i = ((Withit)x$1).value();
+        if($this != i) goto _L2; else goto _L3
+_L3:
+        true;
+          goto _L4
+_L2:
+        false;
+_L4:
+        return;
+    }
+
+    public final String toString$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$._toString(new Withit($this));
+    }
+
+    public volatile Object apply(Object v1)
+    {
+        return new Withit(apply(BoxesRunTime.unboxToInt(v1)));
+    }
+
+    private Withit$()
+    {
+    }
+
+    public static final Withit$ MODULE$ = this;
+
+    static 
+    {
+        new Withit$();
+    }
+}

--- a/jad_scala_2_11_8/Withit.java
+++ b/jad_scala_2_11_8/Withit.java
@@ -1,0 +1,151 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.collection.Iterator;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Withit$
+
+public final class Withit
+    implements Product, Serializable
+{
+
+    public static String toString$extension(int i)
+    {
+        return Withit$.MODULE$.toString$extension(i);
+    }
+
+    public static boolean equals$extension(int i, Object obj)
+    {
+        return Withit$.MODULE$.equals$extension(i, obj);
+    }
+
+    public static int hashCode$extension(int i)
+    {
+        return Withit$.MODULE$.hashCode$extension(i);
+    }
+
+    public static boolean canEqual$extension(int i, Object obj)
+    {
+        return Withit$.MODULE$.canEqual$extension(i, obj);
+    }
+
+    public static Iterator productIterator$extension(int i)
+    {
+        return Withit$.MODULE$.productIterator$extension(i);
+    }
+
+    public static Object productElement$extension(int i, int j)
+    {
+        return Withit$.MODULE$.productElement$extension(i, j);
+    }
+
+    public static int productArity$extension(int i)
+    {
+        return Withit$.MODULE$.productArity$extension(i);
+    }
+
+    public static String productPrefix$extension(int i)
+    {
+        return Withit$.MODULE$.productPrefix$extension(i);
+    }
+
+    public static int copy$default$1$extension(int i)
+    {
+        return Withit$.MODULE$.copy$default$1$extension(i);
+    }
+
+    public static int copy$extension(int i, int j)
+    {
+        return Withit$.MODULE$.copy$extension(i, j);
+    }
+
+    public static Option unapply(int i)
+    {
+        return Withit$.MODULE$.unapply(i);
+    }
+
+    public static int apply(int i)
+    {
+        return Withit$.MODULE$.apply(i);
+    }
+
+    public static Function1 andThen(Function1 function1)
+    {
+        return Withit$.MODULE$.andThen(function1);
+    }
+
+    public static Function1 compose(Function1 function1)
+    {
+        return Withit$.MODULE$.compose(function1);
+    }
+
+    public int value()
+    {
+        return value;
+    }
+
+    public int copy(int value)
+    {
+        return Withit$.MODULE$.copy$extension(value(), value);
+    }
+
+    public int copy$default$1()
+    {
+        return Withit$.MODULE$.copy$default$1$extension(value());
+    }
+
+    public String productPrefix()
+    {
+        return Withit$.MODULE$.productPrefix$extension(value());
+    }
+
+    public int productArity()
+    {
+        return Withit$.MODULE$.productArity$extension(value());
+    }
+
+    public Object productElement(int x$1)
+    {
+        return Withit$.MODULE$.productElement$extension(value(), x$1);
+    }
+
+    public Iterator productIterator()
+    {
+        return Withit$.MODULE$.productIterator$extension(value());
+    }
+
+    public boolean canEqual(Object x$1)
+    {
+        return Withit$.MODULE$.canEqual$extension(value(), x$1);
+    }
+
+    public int hashCode()
+    {
+        return Withit$.MODULE$.hashCode$extension(value());
+    }
+
+    public boolean equals(Object x$1)
+    {
+        return Withit$.MODULE$.equals$extension(value(), x$1);
+    }
+
+    public String toString()
+    {
+        return Withit$.MODULE$.toString$extension(value());
+    }
+
+    public Withit(int value)
+    {
+        this.value = value;
+        super();
+        scala.Product.class.$init$(this);
+    }
+
+    private final int value;
+}

--- a/jad_scala_2_11_8/Without$.java
+++ b/jad_scala_2_11_8/Without$.java
@@ -1,0 +1,54 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.runtime.AbstractFunction1;
+import scala.runtime.BoxesRunTime;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Without
+
+public final class Without$ extends AbstractFunction1
+    implements Serializable
+{
+
+    public final String toString()
+    {
+        return "Without";
+    }
+
+    public Without apply(int value)
+    {
+        return new Without(value);
+    }
+
+    public Option unapply(Without x$0)
+    {
+        return ((Option) (x$0 != null ? new Some(BoxesRunTime.boxToInteger(x$0.value())) : None$.MODULE$));
+    }
+
+    private Object readResolve()
+    {
+        return MODULE$;
+    }
+
+    public volatile Object apply(Object v1)
+    {
+        return apply(BoxesRunTime.unboxToInt(v1));
+    }
+
+    private Without$()
+    {
+    }
+
+    public static final Without$ MODULE$ = this;
+
+    static 
+    {
+        new Without$();
+    }
+}

--- a/jad_scala_2_11_8/Without.java
+++ b/jad_scala_2_11_8/Without.java
@@ -1,0 +1,126 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.collection.Iterator;
+import scala.runtime.*;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Without$
+
+public class Without
+    implements Product, Serializable
+{
+
+    public static Option unapply(Without without)
+    {
+        return Without$.MODULE$.unapply(without);
+    }
+
+    public static Without apply(int i)
+    {
+        return Without$.MODULE$.apply(i);
+    }
+
+    public static Function1 andThen(Function1 function1)
+    {
+        return Without$.MODULE$.andThen(function1);
+    }
+
+    public static Function1 compose(Function1 function1)
+    {
+        return Without$.MODULE$.compose(function1);
+    }
+
+    public int value()
+    {
+        return value;
+    }
+
+    public Without copy(int value)
+    {
+        return new Without(value);
+    }
+
+    public int copy$default$1()
+    {
+        return value();
+    }
+
+    public String productPrefix()
+    {
+        return "Without";
+    }
+
+    public int productArity()
+    {
+        return 1;
+    }
+
+    public Object productElement(int x$1)
+    {
+        switch(x$1)
+        {
+        default:
+            throw new IndexOutOfBoundsException(BoxesRunTime.boxToInteger(x$1).toString());
+
+        case 0: // '\0'
+            return BoxesRunTime.boxToInteger(value());
+        }
+    }
+
+    public Iterator productIterator()
+    {
+        return ScalaRunTime$.MODULE$.typedProductIterator(this);
+    }
+
+    public boolean canEqual(Object x$1)
+    {
+        return x$1 instanceof Without;
+    }
+
+    public int hashCode()
+    {
+        return Statics.finalizeHash(Statics.mix(0xcafebabe, value()), 1);
+    }
+
+    public String toString()
+    {
+        return ScalaRunTime$.MODULE$._toString(this);
+    }
+
+    public boolean equals(Object x$1)
+    {
+        if(this == x$1) goto _L2; else goto _L1
+_L1:
+        boolean flag;
+        if(x$1 instanceof Without)
+            flag = true;
+        else
+            flag = false;
+        if(!flag) goto _L4; else goto _L3
+_L3:
+        Without without = (Without)x$1;
+        if(value() != without.value() || !without.canEqual(this)) goto _L4; else goto _L2
+_L2:
+        true;
+          goto _L5
+_L4:
+        false;
+_L5:
+        return;
+    }
+
+    public Without(int value)
+    {
+        this.value = value;
+        super();
+        scala.Product.class.$init$(this);
+    }
+
+    private final int value;
+}

--- a/jad_scala_2_11_8/implicitClasses$.java
+++ b/jad_scala_2_11_8/implicitClasses$.java
@@ -5,7 +5,6 @@
 
 package org.openjdk.jmh.samples;
 
-import scala.Option;
 
 // Referenced classes of package org.openjdk.jmh.samples:
 //            implicitClasses
@@ -13,29 +12,29 @@ import scala.Option;
 public final class implicitClasses$
 {
 
-    public implicitClasses.ImplicitStandard ImplicitStandard(Option oa)
+    public implicitClasses.ImplicitStandard ImplicitStandard(int i)
     {
-        return new implicitClasses.ImplicitStandard(oa);
+        return new implicitClasses.ImplicitStandard(i);
     }
 
-    public Option ImplicitAnyVal(Option oa)
+    public int ImplicitAnyVal(int i)
     {
-        return oa;
+        return i;
     }
 
-    public Option ImplicitInlineBothAnyVal(Option oa)
+    public int ImplicitInlineBothAnyVal(int i)
     {
-        return oa;
+        return i;
     }
 
-    public Option ImplicitInlineFunAnyVal(Option oa)
+    public int ImplicitInlineFunAnyVal(int i)
     {
-        return oa;
+        return i;
     }
 
-    public Option ImplicitInlineClassAnyVal(Option oa)
+    public int ImplicitInlineClassAnyVal(int i)
     {
-        return oa;
+        return i;
     }
 
     private implicitClasses$()

--- a/jad_scala_2_11_8/implicitClasses$.java
+++ b/jad_scala_2_11_8/implicitClasses$.java
@@ -1,0 +1,51 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitClasses
+
+public final class implicitClasses$
+{
+
+    public implicitClasses.ImplicitStandard ImplicitStandard(Option oa)
+    {
+        return new implicitClasses.ImplicitStandard(oa);
+    }
+
+    public Option ImplicitAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option ImplicitInlineBothAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option ImplicitInlineFunAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option ImplicitInlineClassAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    private implicitClasses$()
+    {
+    }
+
+    public static final implicitClasses$ MODULE$ = this;
+
+    static 
+    {
+        new implicitClasses$();
+    }
+}

--- a/jad_scala_2_11_8/implicitClasses.java
+++ b/jad_scala_2_11_8/implicitClasses.java
@@ -5,7 +5,7 @@
 
 package org.openjdk.jmh.samples;
 
-import scala.Option;
+import scala.runtime.BoxesRunTime;
 
 // Referenced classes of package org.openjdk.jmh.samples:
 //            implicitClasses$
@@ -15,31 +15,31 @@ public final class implicitClasses
     public static final class ImplicitAnyVal
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public int hashCode()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public boolean equals(Object x$1)
         {
-            return .MODULE..extension(oa(), x$1);
+            return .MODULE..extension(i(), x$1);
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitAnyVal(Option oa)
+        public ImplicitAnyVal(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -47,17 +47,17 @@ public final class implicitClasses
     public static class ImplicitAnyVal.
     {
 
-        public final boolean bar$extension(Option $this)
+        public final int bar$extension(int $this)
         {
-            return $this.isDefined();
+            return $this + 2;
         }
 
-        public final int hashCode$extension(Option $this)
+        public final int hashCode$extension(int $this)
         {
-            return $this.hashCode();
+            return BoxesRunTime.boxToInteger($this).hashCode();
         }
 
-        public final boolean equals$extension(Option $this, Object x$1)
+        public final boolean equals$extension(int $this, Object x$1)
         {
             boolean flag;
             if(x$1 instanceof ImplicitAnyVal)
@@ -66,27 +66,14 @@ public final class implicitClasses
                 flag = false;
             if(!flag) goto _L2; else goto _L1
 _L1:
-            Option option = x$1 != null ? ((ImplicitAnyVal)x$1).oa() : null;
-            $this;
-            if($this != null) goto _L4; else goto _L3
+            int i = ((ImplicitAnyVal)x$1).i();
+            if($this != i) goto _L2; else goto _L3
 _L3:
-            JVM INSTR pop ;
-            if(option == null) goto _L6; else goto _L5
-_L4:
-            option;
-            equals();
-            JVM INSTR ifeq 61;
-               goto _L6 _L5
-_L6:
-            if(true) goto _L7; else goto _L2
-_L5:
-            if(true) goto _L2; else goto _L7
-_L7:
             true;
-              goto _L8
+              goto _L4
 _L2:
             false;
-_L8:
+_L4:
             return;
         }
 
@@ -105,21 +92,21 @@ _L8:
     public static final class ImplicitStandard
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return oa().isDefined();
+            return i() + 2;
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitStandard(Option oa)
+        public ImplicitStandard(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -127,31 +114,31 @@ _L8:
     public static final class ImplicitInlineFunAnyVal
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public int hashCode()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public boolean equals(Object x$1)
         {
-            return .MODULE..extension(oa(), x$1);
+            return .MODULE..extension(i(), x$1);
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitInlineFunAnyVal(Option oa)
+        public ImplicitInlineFunAnyVal(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -159,17 +146,17 @@ _L8:
     public static class ImplicitInlineFunAnyVal.
     {
 
-        public final boolean bar$extension(Option $this)
+        public final int bar$extension(int $this)
         {
-            return $this.isDefined();
+            return $this + 2;
         }
 
-        public final int hashCode$extension(Option $this)
+        public final int hashCode$extension(int $this)
         {
-            return $this.hashCode();
+            return BoxesRunTime.boxToInteger($this).hashCode();
         }
 
-        public final boolean equals$extension(Option $this, Object x$1)
+        public final boolean equals$extension(int $this, Object x$1)
         {
             boolean flag;
             if(x$1 instanceof ImplicitInlineFunAnyVal)
@@ -178,27 +165,14 @@ _L8:
                 flag = false;
             if(!flag) goto _L2; else goto _L1
 _L1:
-            Option option = x$1 != null ? ((ImplicitInlineFunAnyVal)x$1).oa() : null;
-            $this;
-            if($this != null) goto _L4; else goto _L3
+            int i = ((ImplicitInlineFunAnyVal)x$1).i();
+            if($this != i) goto _L2; else goto _L3
 _L3:
-            JVM INSTR pop ;
-            if(option == null) goto _L6; else goto _L5
-_L4:
-            option;
-            equals();
-            JVM INSTR ifeq 61;
-               goto _L6 _L5
-_L6:
-            if(true) goto _L7; else goto _L2
-_L5:
-            if(true) goto _L2; else goto _L7
-_L7:
             true;
-              goto _L8
+              goto _L4
 _L2:
             false;
-_L8:
+_L4:
             return;
         }
 
@@ -217,31 +191,31 @@ _L8:
     public static final class ImplicitInlineBothAnyVal
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public int hashCode()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public boolean equals(Object x$1)
         {
-            return .MODULE..extension(oa(), x$1);
+            return .MODULE..extension(i(), x$1);
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitInlineBothAnyVal(Option oa)
+        public ImplicitInlineBothAnyVal(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -249,17 +223,17 @@ _L8:
     public static class ImplicitInlineBothAnyVal.
     {
 
-        public final boolean bar$extension(Option $this)
+        public final int bar$extension(int $this)
         {
-            return $this.isDefined();
+            return $this + 2;
         }
 
-        public final int hashCode$extension(Option $this)
+        public final int hashCode$extension(int $this)
         {
-            return $this.hashCode();
+            return BoxesRunTime.boxToInteger($this).hashCode();
         }
 
-        public final boolean equals$extension(Option $this, Object x$1)
+        public final boolean equals$extension(int $this, Object x$1)
         {
             boolean flag;
             if(x$1 instanceof ImplicitInlineBothAnyVal)
@@ -268,27 +242,14 @@ _L8:
                 flag = false;
             if(!flag) goto _L2; else goto _L1
 _L1:
-            Option option = x$1 != null ? ((ImplicitInlineBothAnyVal)x$1).oa() : null;
-            $this;
-            if($this != null) goto _L4; else goto _L3
+            int i = ((ImplicitInlineBothAnyVal)x$1).i();
+            if($this != i) goto _L2; else goto _L3
 _L3:
-            JVM INSTR pop ;
-            if(option == null) goto _L6; else goto _L5
-_L4:
-            option;
-            equals();
-            JVM INSTR ifeq 61;
-               goto _L6 _L5
-_L6:
-            if(true) goto _L7; else goto _L2
-_L5:
-            if(true) goto _L2; else goto _L7
-_L7:
             true;
-              goto _L8
+              goto _L4
 _L2:
             false;
-_L8:
+_L4:
             return;
         }
 
@@ -307,31 +268,31 @@ _L8:
     public static final class ImplicitInlineClassAnyVal
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public int hashCode()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public boolean equals(Object x$1)
         {
-            return .MODULE..extension(oa(), x$1);
+            return .MODULE..extension(i(), x$1);
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitInlineClassAnyVal(Option oa)
+        public ImplicitInlineClassAnyVal(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -339,17 +300,17 @@ _L8:
     public static class ImplicitInlineClassAnyVal.
     {
 
-        public final boolean bar$extension(Option $this)
+        public final int bar$extension(int $this)
         {
-            return $this.isDefined();
+            return $this + 2;
         }
 
-        public final int hashCode$extension(Option $this)
+        public final int hashCode$extension(int $this)
         {
-            return $this.hashCode();
+            return BoxesRunTime.boxToInteger($this).hashCode();
         }
 
-        public final boolean equals$extension(Option $this, Object x$1)
+        public final boolean equals$extension(int $this, Object x$1)
         {
             boolean flag;
             if(x$1 instanceof ImplicitInlineClassAnyVal)
@@ -358,27 +319,14 @@ _L8:
                 flag = false;
             if(!flag) goto _L2; else goto _L1
 _L1:
-            Option option = x$1 != null ? ((ImplicitInlineClassAnyVal)x$1).oa() : null;
-            $this;
-            if($this != null) goto _L4; else goto _L3
+            int i = ((ImplicitInlineClassAnyVal)x$1).i();
+            if($this != i) goto _L2; else goto _L3
 _L3:
-            JVM INSTR pop ;
-            if(option == null) goto _L6; else goto _L5
-_L4:
-            option;
-            equals();
-            JVM INSTR ifeq 61;
-               goto _L6 _L5
-_L6:
-            if(true) goto _L7; else goto _L2
-_L5:
-            if(true) goto _L2; else goto _L7
-_L7:
             true;
-              goto _L8
+              goto _L4
 _L2:
             false;
-_L8:
+_L4:
             return;
         }
 
@@ -395,28 +343,28 @@ _L8:
     }
 
 
-    public static Option ImplicitInlineClassAnyVal(Option option)
+    public static int ImplicitInlineClassAnyVal(int i)
     {
-        return implicitClasses$.MODULE$.ImplicitInlineClassAnyVal(option);
+        return implicitClasses$.MODULE$.ImplicitInlineClassAnyVal(i);
     }
 
-    public static Option ImplicitInlineFunAnyVal(Option option)
+    public static int ImplicitInlineFunAnyVal(int i)
     {
-        return implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(option);
+        return implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(i);
     }
 
-    public static Option ImplicitInlineBothAnyVal(Option option)
+    public static int ImplicitInlineBothAnyVal(int i)
     {
-        return implicitClasses$.MODULE$.ImplicitInlineBothAnyVal(option);
+        return implicitClasses$.MODULE$.ImplicitInlineBothAnyVal(i);
     }
 
-    public static Option ImplicitAnyVal(Option option)
+    public static int ImplicitAnyVal(int i)
     {
-        return implicitClasses$.MODULE$.ImplicitAnyVal(option);
+        return implicitClasses$.MODULE$.ImplicitAnyVal(i);
     }
 
-    public static ImplicitStandard ImplicitStandard(Option option)
+    public static ImplicitStandard ImplicitStandard(int i)
     {
-        return implicitClasses$.MODULE$.ImplicitStandard(option);
+        return implicitClasses$.MODULE$.ImplicitStandard(i);
     }
 }

--- a/jad_scala_2_11_8/implicitClasses.java
+++ b/jad_scala_2_11_8/implicitClasses.java
@@ -1,0 +1,422 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitClasses$
+
+public final class implicitClasses
+{
+    public static final class ImplicitAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            boolean flag;
+            if(x$1 instanceof ImplicitAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag) goto _L2; else goto _L1
+_L1:
+            Option option = x$1 != null ? ((ImplicitAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null) goto _L4; else goto _L3
+_L3:
+            JVM INSTR pop ;
+            if(option == null) goto _L6; else goto _L5
+_L4:
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L6 _L5
+_L6:
+            if(true) goto _L7; else goto _L2
+_L5:
+            if(true) goto _L2; else goto _L7
+_L7:
+            true;
+              goto _L8
+_L2:
+            false;
+_L8:
+            return;
+        }
+
+        public static final ImplicitAnyVal. MODULE$ = this;
+
+        static 
+        {
+            new ImplicitAnyVal.();
+        }
+
+        public ImplicitAnyVal.()
+        {
+        }
+    }
+
+    public static final class ImplicitStandard
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return oa().isDefined();
+        }
+
+        private final Option oa;
+
+        public ImplicitStandard(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static final class ImplicitInlineFunAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineFunAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineFunAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineFunAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag) goto _L2; else goto _L1
+_L1:
+            Option option = x$1 != null ? ((ImplicitInlineFunAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null) goto _L4; else goto _L3
+_L3:
+            JVM INSTR pop ;
+            if(option == null) goto _L6; else goto _L5
+_L4:
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L6 _L5
+_L6:
+            if(true) goto _L7; else goto _L2
+_L5:
+            if(true) goto _L2; else goto _L7
+_L7:
+            true;
+              goto _L8
+_L2:
+            false;
+_L8:
+            return;
+        }
+
+        public static final ImplicitInlineFunAnyVal. MODULE$ = this;
+
+        static 
+        {
+            new ImplicitInlineFunAnyVal.();
+        }
+
+        public ImplicitInlineFunAnyVal.()
+        {
+        }
+    }
+
+    public static final class ImplicitInlineBothAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineBothAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineBothAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineBothAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag) goto _L2; else goto _L1
+_L1:
+            Option option = x$1 != null ? ((ImplicitInlineBothAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null) goto _L4; else goto _L3
+_L3:
+            JVM INSTR pop ;
+            if(option == null) goto _L6; else goto _L5
+_L4:
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L6 _L5
+_L6:
+            if(true) goto _L7; else goto _L2
+_L5:
+            if(true) goto _L2; else goto _L7
+_L7:
+            true;
+              goto _L8
+_L2:
+            false;
+_L8:
+            return;
+        }
+
+        public static final ImplicitInlineBothAnyVal. MODULE$ = this;
+
+        static 
+        {
+            new ImplicitInlineBothAnyVal.();
+        }
+
+        public ImplicitInlineBothAnyVal.()
+        {
+        }
+    }
+
+    public static final class ImplicitInlineClassAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineClassAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineClassAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineClassAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag) goto _L2; else goto _L1
+_L1:
+            Option option = x$1 != null ? ((ImplicitInlineClassAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null) goto _L4; else goto _L3
+_L3:
+            JVM INSTR pop ;
+            if(option == null) goto _L6; else goto _L5
+_L4:
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L6 _L5
+_L6:
+            if(true) goto _L7; else goto _L2
+_L5:
+            if(true) goto _L2; else goto _L7
+_L7:
+            true;
+              goto _L8
+_L2:
+            false;
+_L8:
+            return;
+        }
+
+        public static final ImplicitInlineClassAnyVal. MODULE$ = this;
+
+        static 
+        {
+            new ImplicitInlineClassAnyVal.();
+        }
+
+        public ImplicitInlineClassAnyVal.()
+        {
+        }
+    }
+
+
+    public static Option ImplicitInlineClassAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitInlineClassAnyVal(option);
+    }
+
+    public static Option ImplicitInlineFunAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(option);
+    }
+
+    public static Option ImplicitInlineBothAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitInlineBothAnyVal(option);
+    }
+
+    public static Option ImplicitAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitAnyVal(option);
+    }
+
+    public static ImplicitStandard ImplicitStandard(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitStandard(option);
+    }
+}

--- a/jad_scala_2_11_8/implicitFunctions$.java
+++ b/jad_scala_2_11_8/implicitFunctions$.java
@@ -5,7 +5,6 @@
 
 package org.openjdk.jmh.samples;
 
-import scala.Option;
 
 // Referenced classes of package org.openjdk.jmh.samples:
 //            implicitFunctions
@@ -13,19 +12,19 @@ import scala.Option;
 public final class implicitFunctions$
 {
 
-    public implicitFunctions.ImplicitStandard toStandard(Option oa)
+    public implicitFunctions.ImplicitStandard toStandard(int i)
     {
-        return new implicitFunctions.ImplicitStandard(oa);
+        return new implicitFunctions.ImplicitStandard(i);
     }
 
-    public Option toAnyVal(Option oa)
+    public int toAnyVal(int i)
     {
-        return oa;
+        return i;
     }
 
-    public Option toInlineAnyVal(Option oa)
+    public int toInlineAnyVal(int i)
     {
-        return oa;
+        return i;
     }
 
     private implicitFunctions$()

--- a/jad_scala_2_11_8/implicitFunctions$.java
+++ b/jad_scala_2_11_8/implicitFunctions$.java
@@ -1,0 +1,41 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitFunctions
+
+public final class implicitFunctions$
+{
+
+    public implicitFunctions.ImplicitStandard toStandard(Option oa)
+    {
+        return new implicitFunctions.ImplicitStandard(oa);
+    }
+
+    public Option toAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option toInlineAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    private implicitFunctions$()
+    {
+    }
+
+    public static final implicitFunctions$ MODULE$ = this;
+
+    static 
+    {
+        new implicitFunctions$();
+    }
+}

--- a/jad_scala_2_11_8/implicitFunctions.java
+++ b/jad_scala_2_11_8/implicitFunctions.java
@@ -1,0 +1,232 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitFunctions$
+
+public final class implicitFunctions
+{
+    public static final class ImplicitAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            boolean flag;
+            if(x$1 instanceof ImplicitAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag) goto _L2; else goto _L1
+_L1:
+            Option option = x$1 != null ? ((ImplicitAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null) goto _L4; else goto _L3
+_L3:
+            JVM INSTR pop ;
+            if(option == null) goto _L6; else goto _L5
+_L4:
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L6 _L5
+_L6:
+            if(true) goto _L7; else goto _L2
+_L5:
+            if(true) goto _L2; else goto _L7
+_L7:
+            true;
+              goto _L8
+_L2:
+            false;
+_L8:
+            return;
+        }
+
+        public static final ImplicitAnyVal. MODULE$ = this;
+
+        static 
+        {
+            new ImplicitAnyVal.();
+        }
+
+        public ImplicitAnyVal.()
+        {
+        }
+    }
+
+    public static final class ImplicitStandard
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return oa().isDefined();
+        }
+
+        private final Option oa;
+
+        public ImplicitStandard(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static final class ImplicitInlineAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag) goto _L2; else goto _L1
+_L1:
+            Option option = x$1 != null ? ((ImplicitInlineAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null) goto _L4; else goto _L3
+_L3:
+            JVM INSTR pop ;
+            if(option == null) goto _L6; else goto _L5
+_L4:
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L6 _L5
+_L6:
+            if(true) goto _L7; else goto _L2
+_L5:
+            if(true) goto _L2; else goto _L7
+_L7:
+            true;
+              goto _L8
+_L2:
+            false;
+_L8:
+            return;
+        }
+
+        public static final ImplicitInlineAnyVal. MODULE$ = this;
+
+        static 
+        {
+            new ImplicitInlineAnyVal.();
+        }
+
+        public ImplicitInlineAnyVal.()
+        {
+        }
+    }
+
+
+    public static Option toInlineAnyVal(Option option)
+    {
+        return implicitFunctions$.MODULE$.toInlineAnyVal(option);
+    }
+
+    public static Option toAnyVal(Option option)
+    {
+        return implicitFunctions$.MODULE$.toAnyVal(option);
+    }
+
+    public static ImplicitStandard toStandard(Option option)
+    {
+        return implicitFunctions$.MODULE$.toStandard(option);
+    }
+}

--- a/jad_scala_2_11_8/implicitFunctions.java
+++ b/jad_scala_2_11_8/implicitFunctions.java
@@ -5,7 +5,7 @@
 
 package org.openjdk.jmh.samples;
 
-import scala.Option;
+import scala.runtime.BoxesRunTime;
 
 // Referenced classes of package org.openjdk.jmh.samples:
 //            implicitFunctions$
@@ -15,31 +15,31 @@ public final class implicitFunctions
     public static final class ImplicitAnyVal
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public int hashCode()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public boolean equals(Object x$1)
         {
-            return .MODULE..extension(oa(), x$1);
+            return .MODULE..extension(i(), x$1);
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitAnyVal(Option oa)
+        public ImplicitAnyVal(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -47,17 +47,17 @@ public final class implicitFunctions
     public static class ImplicitAnyVal.
     {
 
-        public final boolean bar$extension(Option $this)
+        public final int bar$extension(int $this)
         {
-            return $this.isDefined();
+            return $this + 2;
         }
 
-        public final int hashCode$extension(Option $this)
+        public final int hashCode$extension(int $this)
         {
-            return $this.hashCode();
+            return BoxesRunTime.boxToInteger($this).hashCode();
         }
 
-        public final boolean equals$extension(Option $this, Object x$1)
+        public final boolean equals$extension(int $this, Object x$1)
         {
             boolean flag;
             if(x$1 instanceof ImplicitAnyVal)
@@ -66,27 +66,14 @@ public final class implicitFunctions
                 flag = false;
             if(!flag) goto _L2; else goto _L1
 _L1:
-            Option option = x$1 != null ? ((ImplicitAnyVal)x$1).oa() : null;
-            $this;
-            if($this != null) goto _L4; else goto _L3
+            int i = ((ImplicitAnyVal)x$1).i();
+            if($this != i) goto _L2; else goto _L3
 _L3:
-            JVM INSTR pop ;
-            if(option == null) goto _L6; else goto _L5
-_L4:
-            option;
-            equals();
-            JVM INSTR ifeq 61;
-               goto _L6 _L5
-_L6:
-            if(true) goto _L7; else goto _L2
-_L5:
-            if(true) goto _L2; else goto _L7
-_L7:
             true;
-              goto _L8
+              goto _L4
 _L2:
             false;
-_L8:
+_L4:
             return;
         }
 
@@ -105,21 +92,21 @@ _L8:
     public static final class ImplicitStandard
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return oa().isDefined();
+            return i() + 2;
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitStandard(Option oa)
+        public ImplicitStandard(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -127,31 +114,31 @@ _L8:
     public static final class ImplicitInlineAnyVal
     {
 
-        public Option oa()
+        public int i()
         {
-            return oa;
+            return i;
         }
 
-        public boolean bar()
+        public int bar()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public int hashCode()
         {
-            return .MODULE..extension(oa());
+            return .MODULE..extension(i());
         }
 
         public boolean equals(Object x$1)
         {
-            return .MODULE..extension(oa(), x$1);
+            return .MODULE..extension(i(), x$1);
         }
 
-        private final Option oa;
+        private final int i;
 
-        public ImplicitInlineAnyVal(Option oa)
+        public ImplicitInlineAnyVal(int i)
         {
-            this.oa = oa;
+            this.i = i;
             super();
         }
     }
@@ -159,17 +146,17 @@ _L8:
     public static class ImplicitInlineAnyVal.
     {
 
-        public final boolean bar$extension(Option $this)
+        public final int bar$extension(int $this)
         {
-            return $this.isDefined();
+            return $this + 2;
         }
 
-        public final int hashCode$extension(Option $this)
+        public final int hashCode$extension(int $this)
         {
-            return $this.hashCode();
+            return BoxesRunTime.boxToInteger($this).hashCode();
         }
 
-        public final boolean equals$extension(Option $this, Object x$1)
+        public final boolean equals$extension(int $this, Object x$1)
         {
             boolean flag;
             if(x$1 instanceof ImplicitInlineAnyVal)
@@ -178,27 +165,14 @@ _L8:
                 flag = false;
             if(!flag) goto _L2; else goto _L1
 _L1:
-            Option option = x$1 != null ? ((ImplicitInlineAnyVal)x$1).oa() : null;
-            $this;
-            if($this != null) goto _L4; else goto _L3
+            int i = ((ImplicitInlineAnyVal)x$1).i();
+            if($this != i) goto _L2; else goto _L3
 _L3:
-            JVM INSTR pop ;
-            if(option == null) goto _L6; else goto _L5
-_L4:
-            option;
-            equals();
-            JVM INSTR ifeq 61;
-               goto _L6 _L5
-_L6:
-            if(true) goto _L7; else goto _L2
-_L5:
-            if(true) goto _L2; else goto _L7
-_L7:
             true;
-              goto _L8
+              goto _L4
 _L2:
             false;
-_L8:
+_L4:
             return;
         }
 
@@ -215,18 +189,18 @@ _L8:
     }
 
 
-    public static Option toInlineAnyVal(Option option)
+    public static int toInlineAnyVal(int i)
     {
-        return implicitFunctions$.MODULE$.toInlineAnyVal(option);
+        return implicitFunctions$.MODULE$.toInlineAnyVal(i);
     }
 
-    public static Option toAnyVal(Option option)
+    public static int toAnyVal(int i)
     {
-        return implicitFunctions$.MODULE$.toAnyVal(option);
+        return implicitFunctions$.MODULE$.toAnyVal(i);
     }
 
-    public static ImplicitStandard toStandard(Option option)
+    public static ImplicitStandard toStandard(int i)
     {
-        return implicitFunctions$.MODULE$.toStandard(option);
+        return implicitFunctions$.MODULE$.toStandard(i);
     }
 }

--- a/jad_scala_2_11_8/implicits$.java
+++ b/jad_scala_2_11_8/implicits$.java
@@ -1,0 +1,28 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.concurrent.duration.FiniteDuration;
+
+public final class implicits$
+{
+
+    public FiniteDuration LilaPimpedFiniteDuration(FiniteDuration self)
+    {
+        return self;
+    }
+
+    private implicits$()
+    {
+    }
+
+    public static final implicits$ MODULE$ = this;
+
+    static 
+    {
+        new implicits$();
+    }
+}

--- a/jad_scala_2_11_8/implicits.java
+++ b/jad_scala_2_11_8/implicits.java
@@ -1,0 +1,110 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.concurrent.duration.FiniteDuration;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicits$
+
+public final class implicits
+{
+    public static final class LilaPimpedFiniteDuration
+    {
+
+        public FiniteDuration self()
+        {
+            return self;
+        }
+
+        public long toHundredths()
+        {
+            return .MODULE..extension(self());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(self());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(self(), x$1);
+        }
+
+        private final FiniteDuration self;
+
+        public LilaPimpedFiniteDuration(FiniteDuration self)
+        {
+            this.self = self;
+            super();
+        }
+    }
+
+    public static class LilaPimpedFiniteDuration.
+    {
+
+        public final long toHundredths$extension(FiniteDuration $this)
+        {
+            return $this.toMillis() / 10L;
+        }
+
+        public final int hashCode$extension(FiniteDuration $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(FiniteDuration $this, Object x$1)
+        {
+            boolean flag;
+            if(x$1 instanceof LilaPimpedFiniteDuration)
+                flag = true;
+            else
+                flag = false;
+            if(!flag) goto _L2; else goto _L1
+_L1:
+            FiniteDuration finiteduration = x$1 != null ? ((LilaPimpedFiniteDuration)x$1).self() : null;
+            $this;
+            if($this != null) goto _L4; else goto _L3
+_L3:
+            JVM INSTR pop ;
+            if(finiteduration == null) goto _L6; else goto _L5
+_L4:
+            finiteduration;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L6 _L5
+_L6:
+            if(true) goto _L7; else goto _L2
+_L5:
+            if(true) goto _L2; else goto _L7
+_L7:
+            true;
+              goto _L8
+_L2:
+            false;
+_L8:
+            return;
+        }
+
+        public static final LilaPimpedFiniteDuration. MODULE$ = this;
+
+        static 
+        {
+            new LilaPimpedFiniteDuration.();
+        }
+
+        public LilaPimpedFiniteDuration.()
+        {
+        }
+    }
+
+
+    public static FiniteDuration LilaPimpedFiniteDuration(FiniteDuration finiteduration)
+    {
+        return implicits$.MODULE$.LilaPimpedFiniteDuration(finiteduration);
+    }
+}

--- a/jad_scala_2_12_1/AnyValTest.java
+++ b/jad_scala_2_12_1/AnyValTest.java
@@ -1,0 +1,28 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Without
+
+public class AnyValTest
+{
+
+    public Without testWithout()
+    {
+        return new Without(42);
+    }
+
+    public int testWithit()
+    {
+        return 42;
+    }
+
+    public AnyValTest()
+    {
+    }
+}

--- a/jad_scala_2_12_1/Centis$.java
+++ b/jad_scala_2_12_1/Centis$.java
@@ -1,0 +1,122 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.collection.Iterator;
+import scala.runtime.*;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Centis
+
+public final class Centis$ extends AbstractFunction1
+    implements Serializable
+{
+
+    public final String toString()
+    {
+        return "Centis";
+    }
+
+    public int apply(int cs)
+    {
+        return cs;
+    }
+
+    public Option unapply(int x$0)
+    {
+        new Centis(x$0);
+        return new Some(BoxesRunTime.boxToInteger(x$0));
+    }
+
+    private Object readResolve()
+    {
+        return MODULE$;
+    }
+
+    public final int copy$extension(int $this, int cs)
+    {
+        return cs;
+    }
+
+    public final int copy$default$1$extension(int $this)
+    {
+        return $this;
+    }
+
+    public final String productPrefix$extension(int $this)
+    {
+        return "Centis";
+    }
+
+    public final int productArity$extension(int $this)
+    {
+        return 1;
+    }
+
+    public final Object productElement$extension(int $this, int x$1)
+    {
+        switch(x$1)
+        {
+        case 0: // '\0'
+            return BoxesRunTime.boxToInteger($this);
+        }
+        throw new IndexOutOfBoundsException(BoxesRunTime.boxToInteger(x$1).toString());
+    }
+
+    public final Iterator productIterator$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$.typedProductIterator(new Centis($this));
+    }
+
+    public final boolean canEqual$extension(int $this, Object x$1)
+    {
+        return x$1 instanceof Integer;
+    }
+
+    public final int hashCode$extension(int $this)
+    {
+        return BoxesRunTime.boxToInteger($this).hashCode();
+    }
+
+    public final boolean equals$extension(int $this, Object x$1)
+    {
+        boolean flag;
+        if(x$1 instanceof Centis)
+            flag = true;
+        else
+            flag = false;
+        if(flag)
+        {
+            int i = ((Centis)x$1).cs();
+            if($this == i)
+                return true;
+        }
+        return false;
+    }
+
+    public final String toString$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$._toString(new Centis($this));
+    }
+
+    public volatile Object apply(Object v1)
+    {
+        return new Centis(apply(BoxesRunTime.unboxToInt(v1)));
+    }
+
+    private Centis$()
+    {
+        MODULE$ = this;
+    }
+
+    public static Centis$ MODULE$;
+
+    static 
+    {
+        new Centis$();
+    }
+}

--- a/jad_scala_2_12_1/ImplicitClassTest.java
+++ b/jad_scala_2_12_1/ImplicitClassTest.java
@@ -1,0 +1,109 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+import scala.Option$;
+import scala.runtime.BoxesRunTime;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitClasses, implicitFunctions, implicitClasses$, implicitFunctions$
+
+public class ImplicitClassTest
+{
+
+    public Option option()
+    {
+        return option;
+    }
+
+    public boolean testClassStandard()
+    {
+        return implicitClasses$.MODULE$.ImplicitStandard(option()).bar();
+    }
+
+    public boolean testClassAnyVal()
+    {
+        return implicitClasses.ImplicitAnyVal..MODULE$.bar$extension(implicitClasses$.MODULE$.ImplicitAnyVal(option()));
+    }
+
+    public boolean testClassInlineBothAnyVal()
+    {
+        implicitClasses.ImplicitInlineBothAnyVal..MODULE$;
+        Option option1 = implicitClasses$.MODULE$.ImplicitInlineBothAnyVal(option());
+        JVM INSTR ifnonnull 19;
+           goto _L1 _L2
+_L1:
+        break MISSING_BLOCK_LABEL_17;
+_L2:
+        break MISSING_BLOCK_LABEL_19;
+        throw null;
+        return option1.isDefined();
+    }
+
+    public boolean testClassImplicitInlineFunAnyVal()
+    {
+        implicitClasses.ImplicitInlineFunAnyVal..MODULE$;
+        Option option1 = implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(option());
+        JVM INSTR ifnonnull 19;
+           goto _L1 _L2
+_L1:
+        break MISSING_BLOCK_LABEL_17;
+_L2:
+        break MISSING_BLOCK_LABEL_19;
+        throw null;
+        return option1.isDefined();
+    }
+
+    public boolean testClassImplicitInlineClassAnyVal()
+    {
+        return implicitClasses.ImplicitInlineClassAnyVal..MODULE$.bar$extension(implicitClasses$.MODULE$.ImplicitInlineClassAnyVal(option()));
+    }
+
+    public boolean testFunctionStandard()
+    {
+        return implicitFunctions$.MODULE$.toStandard(option()).bar();
+    }
+
+    public boolean testFunctionAnyVal()
+    {
+        return implicitFunctions.ImplicitAnyVal..MODULE$.bar$extension(implicitFunctions$.MODULE$.toAnyVal(option()));
+    }
+
+    public boolean testFunctionInlineAnyVal()
+    {
+        implicitFunctions.ImplicitInlineAnyVal..MODULE$;
+        implicitFunctions$.MODULE$;
+        Option option1 = option();
+        JVM INSTR ifnonnull 16;
+           goto _L1 _L2
+_L1:
+        break MISSING_BLOCK_LABEL_14;
+_L2:
+        break MISSING_BLOCK_LABEL_16;
+        throw null;
+        JVM INSTR ifnonnull 21;
+           goto _L3 _L4
+_L3:
+        break MISSING_BLOCK_LABEL_19;
+_L4:
+        break MISSING_BLOCK_LABEL_21;
+        throw null;
+        return option1.isDefined();
+    }
+
+    public boolean baseline()
+    {
+        return option().isDefined();
+    }
+
+    public ImplicitClassTest()
+    {
+        option = Option$.MODULE$.apply(BoxesRunTime.boxToInteger(42));
+    }
+
+    private final Option option;
+}

--- a/jad_scala_2_12_1/LinearEstimateTest.java
+++ b/jad_scala_2_12_1/LinearEstimateTest.java
@@ -1,0 +1,105 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   LinearEstimateTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.LinearEstimator;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class LinearEstimateTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public final void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public void testEncode()
+    {
+        LinearEstimator.encode(trunced(), startTime());
+    }
+
+    public LinearEstimateTest()
+    {
+        EncodingTestData.$init$(this);
+    }
+
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_12_1/LowBitTruncTest.java
+++ b/jad_scala_2_12_1/LowBitTruncTest.java
@@ -1,0 +1,111 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   LowBitTruncTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.LowBitTruncator;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class LowBitTruncTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public final void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public int[] testData()
+    {
+        return testData;
+    }
+
+    public void testEncode()
+    {
+        LowBitTruncator.truncate(testData());
+    }
+
+    public LowBitTruncTest()
+    {
+        EncodingTestData.$init$(this);
+    }
+
+    private final int testData[] = (int[])centis().clone();
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_12_1/NullTest.java
+++ b/jad_scala_2_12_1/NullTest.java
@@ -1,0 +1,94 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   NullTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+import scala.Option$;
+
+public class NullTest
+{
+    public class Foo
+    {
+
+        public NullTest org$openjdk$jmh$samples$NullTest$Foo$$$outer()
+        {
+            return $outer;
+        }
+
+        public final NullTest $outer;
+
+        public Foo()
+        {
+            if(NullTest.this == null)
+            {
+                throw null;
+            } else
+            {
+                this.$outer = NullTest.this;
+                super();
+                return;
+            }
+        }
+    }
+
+
+    public Foo a()
+    {
+        return a;
+    }
+
+    public Foo b()
+    {
+        return b;
+    }
+
+    public boolean isNotNull(Object x)
+    {
+        return x != null;
+    }
+
+    public boolean isNotNullInline(Object x)
+    {
+        return x != null;
+    }
+
+    public boolean testNullWithOption()
+    {
+        return Option$.MODULE$.apply(a()).isDefined();
+    }
+
+    public boolean testDefinedWithOption()
+    {
+        return Option$.MODULE$.apply(b()).isDefined();
+    }
+
+    public boolean testNullWithFunction()
+    {
+        return isNotNull(a());
+    }
+
+    public boolean testDefinedWithFunction()
+    {
+        return isNotNull(b());
+    }
+
+    public boolean testNullWithFunctionInline()
+    {
+        return isNotNullInline(a());
+    }
+
+    public boolean testDefinedWithFunctionInline()
+    {
+        return isNotNullInline(b());
+    }
+
+    public NullTest()
+    {
+    }
+
+    private final Foo a = null;
+    private final Foo b = new Foo();
+}

--- a/jad_scala_2_12_1/OverallEncodingTest.java
+++ b/jad_scala_2_12_1/OverallEncodingTest.java
@@ -1,0 +1,110 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   OverallEncodingTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.Encoder;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class OverallEncodingTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public final void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public byte[] testEncode()
+    {
+        return Encoder.encode(centis(), startTime());
+    }
+
+    public int[] testDecode()
+    {
+        return Encoder.decode(encoded(), moves(), startTime());
+    }
+
+    public OverallEncodingTest()
+    {
+        EncodingTestData.$init$(this);
+    }
+
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_12_1/VarIntEncodingTest.java
+++ b/jad_scala_2_12_1/VarIntEncodingTest.java
@@ -1,0 +1,112 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   VarIntEncodingTest.scala
+
+package org.openjdk.jmh.samples;
+
+import org.lila.clockencoder.*;
+import scala.util.Random;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            EncodingTestData
+
+public class VarIntEncodingTest
+    implements EncodingTestData
+{
+
+    public Random org$openjdk$jmh$samples$EncodingTestData$$r()
+    {
+        return org$openjdk$jmh$samples$EncodingTestData$$r;
+    }
+
+    public int startTime()
+    {
+        return startTime;
+    }
+
+    public int[] centis()
+    {
+        return centis;
+    }
+
+    public int moves()
+    {
+        return moves;
+    }
+
+    public int[] trunced()
+    {
+        return trunced;
+    }
+
+    public int[] encodedRounds()
+    {
+        return encodedRounds;
+    }
+
+    public byte[] encoded()
+    {
+        return encoded;
+    }
+
+    public final void org$openjdk$jmh$samples$EncodingTestData$_setter_$org$openjdk$jmh$samples$EncodingTestData$$r_$eq(Random x$1)
+    {
+        org$openjdk$jmh$samples$EncodingTestData$$r = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$startTime_$eq(int x$1)
+    {
+        startTime = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$centis_$eq(int x$1[])
+    {
+        centis = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$moves_$eq(int x$1)
+    {
+        moves = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$trunced_$eq(int x$1[])
+    {
+        trunced = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encodedRounds_$eq(int x$1[])
+    {
+        encodedRounds = x$1;
+    }
+
+    public void org$openjdk$jmh$samples$EncodingTestData$_setter_$encoded_$eq(byte x$1[])
+    {
+        encoded = x$1;
+    }
+
+    public byte[] testEncode()
+    {
+        BitWriter writer = new BitWriter();
+        VarIntEncoder.write(encodedRounds(), writer);
+        return writer.toArray();
+    }
+
+    public int[] testDecode()
+    {
+        return VarIntEncoder.read(new BitReader(encoded()), moves());
+    }
+
+    public VarIntEncodingTest()
+    {
+        EncodingTestData.$init$(this);
+    }
+
+    private final Random org$openjdk$jmh$samples$EncodingTestData$$r;
+    private final int startTime;
+    private final int centis[];
+    private final int moves;
+    private final int trunced[];
+    private final int encodedRounds[];
+    private final byte encoded[];
+}

--- a/jad_scala_2_12_1/Withit$.java
+++ b/jad_scala_2_12_1/Withit$.java
@@ -1,0 +1,122 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.collection.Iterator;
+import scala.runtime.*;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Withit
+
+public final class Withit$ extends AbstractFunction1
+    implements Serializable
+{
+
+    public final String toString()
+    {
+        return "Withit";
+    }
+
+    public int apply(int value)
+    {
+        return value;
+    }
+
+    public Option unapply(int x$0)
+    {
+        new Withit(x$0);
+        return new Some(BoxesRunTime.boxToInteger(x$0));
+    }
+
+    private Object readResolve()
+    {
+        return MODULE$;
+    }
+
+    public final int copy$extension(int $this, int value)
+    {
+        return value;
+    }
+
+    public final int copy$default$1$extension(int $this)
+    {
+        return $this;
+    }
+
+    public final String productPrefix$extension(int $this)
+    {
+        return "Withit";
+    }
+
+    public final int productArity$extension(int $this)
+    {
+        return 1;
+    }
+
+    public final Object productElement$extension(int $this, int x$1)
+    {
+        switch(x$1)
+        {
+        case 0: // '\0'
+            return BoxesRunTime.boxToInteger($this);
+        }
+        throw new IndexOutOfBoundsException(BoxesRunTime.boxToInteger(x$1).toString());
+    }
+
+    public final Iterator productIterator$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$.typedProductIterator(new Withit($this));
+    }
+
+    public final boolean canEqual$extension(int $this, Object x$1)
+    {
+        return x$1 instanceof Integer;
+    }
+
+    public final int hashCode$extension(int $this)
+    {
+        return BoxesRunTime.boxToInteger($this).hashCode();
+    }
+
+    public final boolean equals$extension(int $this, Object x$1)
+    {
+        boolean flag;
+        if(x$1 instanceof Withit)
+            flag = true;
+        else
+            flag = false;
+        if(flag)
+        {
+            int i = ((Withit)x$1).value();
+            if($this == i)
+                return true;
+        }
+        return false;
+    }
+
+    public final String toString$extension(int $this)
+    {
+        return ScalaRunTime$.MODULE$._toString(new Withit($this));
+    }
+
+    public volatile Object apply(Object v1)
+    {
+        return new Withit(apply(BoxesRunTime.unboxToInt(v1)));
+    }
+
+    private Withit$()
+    {
+        MODULE$ = this;
+    }
+
+    public static Withit$ MODULE$;
+
+    static 
+    {
+        new Withit$();
+    }
+}

--- a/jad_scala_2_12_1/Without$.java
+++ b/jad_scala_2_12_1/Without$.java
@@ -1,0 +1,58 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   AnyValTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.*;
+import scala.runtime.AbstractFunction1;
+import scala.runtime.BoxesRunTime;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            Without
+
+public final class Without$ extends AbstractFunction1
+    implements Serializable
+{
+
+    public final String toString()
+    {
+        return "Without";
+    }
+
+    public Without apply(int value)
+    {
+        return new Without(value);
+    }
+
+    public Option unapply(Without x$0)
+    {
+        if(x$0 == null)
+            return None$.MODULE$;
+        else
+            return new Some(BoxesRunTime.boxToInteger(x$0.value()));
+    }
+
+    private Object readResolve()
+    {
+        return MODULE$;
+    }
+
+    public volatile Object apply(Object v1)
+    {
+        return apply(BoxesRunTime.unboxToInt(v1));
+    }
+
+    private Without$()
+    {
+        MODULE$ = this;
+    }
+
+    public static Without$ MODULE$;
+
+    static 
+    {
+        new Without$();
+    }
+}

--- a/jad_scala_2_12_1/implicitClasses$.java
+++ b/jad_scala_2_12_1/implicitClasses$.java
@@ -1,0 +1,52 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitClasses
+
+public final class implicitClasses$
+{
+
+    public implicitClasses.ImplicitStandard ImplicitStandard(Option oa)
+    {
+        return new implicitClasses.ImplicitStandard(oa);
+    }
+
+    public Option ImplicitAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option ImplicitInlineBothAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option ImplicitInlineFunAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option ImplicitInlineClassAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    private implicitClasses$()
+    {
+        MODULE$ = this;
+    }
+
+    public static implicitClasses$ MODULE$;
+
+    static 
+    {
+        new implicitClasses$();
+    }
+}

--- a/jad_scala_2_12_1/implicitClasses.java
+++ b/jad_scala_2_12_1/implicitClasses.java
@@ -1,0 +1,452 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitClasses$
+
+public final class implicitClasses
+{
+    public static final class ImplicitAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            Option option;
+            boolean flag;
+            if(x$1 instanceof ImplicitAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag)
+                break MISSING_BLOCK_LABEL_67;
+            option = x$1 != null ? ((ImplicitAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null)
+                break MISSING_BLOCK_LABEL_49;
+            JVM INSTR pop ;
+            if(option != null)
+                break MISSING_BLOCK_LABEL_61;
+            break MISSING_BLOCK_LABEL_57;
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_57;
+_L2:
+            break MISSING_BLOCK_LABEL_61;
+            if(false)
+                break MISSING_BLOCK_LABEL_67;
+            break MISSING_BLOCK_LABEL_65;
+            if(true)
+                break MISSING_BLOCK_LABEL_67;
+            return true;
+            return false;
+        }
+
+        public static ImplicitAnyVal. MODULE$;
+
+        static 
+        {
+            new ImplicitAnyVal.();
+        }
+
+        public ImplicitAnyVal.()
+        {
+            MODULE$ = this;
+        }
+    }
+
+    public static final class ImplicitInlineBothAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            .MODULE.;
+            Option option = oa();
+            JVM INSTR ifnonnull 13;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_11;
+_L2:
+            break MISSING_BLOCK_LABEL_13;
+            throw null;
+            return option.isDefined();
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineBothAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineBothAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            Option option;
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineBothAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag)
+                break MISSING_BLOCK_LABEL_67;
+            option = x$1 != null ? ((ImplicitInlineBothAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null)
+                break MISSING_BLOCK_LABEL_49;
+            JVM INSTR pop ;
+            if(option != null)
+                break MISSING_BLOCK_LABEL_61;
+            break MISSING_BLOCK_LABEL_57;
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_57;
+_L2:
+            break MISSING_BLOCK_LABEL_61;
+            if(false)
+                break MISSING_BLOCK_LABEL_67;
+            break MISSING_BLOCK_LABEL_65;
+            if(true)
+                break MISSING_BLOCK_LABEL_67;
+            return true;
+            return false;
+        }
+
+        public static ImplicitInlineBothAnyVal. MODULE$;
+
+        static 
+        {
+            new ImplicitInlineBothAnyVal.();
+        }
+
+        public ImplicitInlineBothAnyVal.()
+        {
+            MODULE$ = this;
+        }
+    }
+
+    public static final class ImplicitInlineClassAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineClassAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineClassAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            Option option;
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineClassAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag)
+                break MISSING_BLOCK_LABEL_67;
+            option = x$1 != null ? ((ImplicitInlineClassAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null)
+                break MISSING_BLOCK_LABEL_49;
+            JVM INSTR pop ;
+            if(option != null)
+                break MISSING_BLOCK_LABEL_61;
+            break MISSING_BLOCK_LABEL_57;
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_57;
+_L2:
+            break MISSING_BLOCK_LABEL_61;
+            if(false)
+                break MISSING_BLOCK_LABEL_67;
+            break MISSING_BLOCK_LABEL_65;
+            if(true)
+                break MISSING_BLOCK_LABEL_67;
+            return true;
+            return false;
+        }
+
+        public static ImplicitInlineClassAnyVal. MODULE$;
+
+        static 
+        {
+            new ImplicitInlineClassAnyVal.();
+        }
+
+        public ImplicitInlineClassAnyVal.()
+        {
+            MODULE$ = this;
+        }
+    }
+
+    public static final class ImplicitInlineFunAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            .MODULE.;
+            Option option = oa();
+            JVM INSTR ifnonnull 13;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_11;
+_L2:
+            break MISSING_BLOCK_LABEL_13;
+            throw null;
+            return option.isDefined();
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineFunAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineFunAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            Option option;
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineFunAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag)
+                break MISSING_BLOCK_LABEL_67;
+            option = x$1 != null ? ((ImplicitInlineFunAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null)
+                break MISSING_BLOCK_LABEL_49;
+            JVM INSTR pop ;
+            if(option != null)
+                break MISSING_BLOCK_LABEL_61;
+            break MISSING_BLOCK_LABEL_57;
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_57;
+_L2:
+            break MISSING_BLOCK_LABEL_61;
+            if(false)
+                break MISSING_BLOCK_LABEL_67;
+            break MISSING_BLOCK_LABEL_65;
+            if(true)
+                break MISSING_BLOCK_LABEL_67;
+            return true;
+            return false;
+        }
+
+        public static ImplicitInlineFunAnyVal. MODULE$;
+
+        static 
+        {
+            new ImplicitInlineFunAnyVal.();
+        }
+
+        public ImplicitInlineFunAnyVal.()
+        {
+            MODULE$ = this;
+        }
+    }
+
+    public static final class ImplicitStandard
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return oa().isDefined();
+        }
+
+        private final Option oa;
+
+        public ImplicitStandard(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+
+    public static Option ImplicitInlineClassAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitInlineClassAnyVal(option);
+    }
+
+    public static Option ImplicitInlineFunAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitInlineFunAnyVal(option);
+    }
+
+    public static Option ImplicitInlineBothAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitInlineBothAnyVal(option);
+    }
+
+    public static Option ImplicitAnyVal(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitAnyVal(option);
+    }
+
+    public static ImplicitStandard ImplicitStandard(Option option)
+    {
+        return implicitClasses$.MODULE$.ImplicitStandard(option);
+    }
+}

--- a/jad_scala_2_12_1/implicitFunctions$.java
+++ b/jad_scala_2_12_1/implicitFunctions$.java
@@ -1,0 +1,42 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitFunctions
+
+public final class implicitFunctions$
+{
+
+    public implicitFunctions.ImplicitStandard toStandard(Option oa)
+    {
+        return new implicitFunctions.ImplicitStandard(oa);
+    }
+
+    public Option toAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    public Option toInlineAnyVal(Option oa)
+    {
+        return oa;
+    }
+
+    private implicitFunctions$()
+    {
+        MODULE$ = this;
+    }
+
+    public static implicitFunctions$ MODULE$;
+
+    static 
+    {
+        new implicitFunctions$();
+    }
+}

--- a/jad_scala_2_12_1/implicitFunctions.java
+++ b/jad_scala_2_12_1/implicitFunctions.java
@@ -1,0 +1,247 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   ImplicitClassTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.Option;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicitFunctions$
+
+public final class implicitFunctions
+{
+    public static final class ImplicitAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            Option option;
+            boolean flag;
+            if(x$1 instanceof ImplicitAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag)
+                break MISSING_BLOCK_LABEL_67;
+            option = x$1 != null ? ((ImplicitAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null)
+                break MISSING_BLOCK_LABEL_49;
+            JVM INSTR pop ;
+            if(option != null)
+                break MISSING_BLOCK_LABEL_61;
+            break MISSING_BLOCK_LABEL_57;
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_57;
+_L2:
+            break MISSING_BLOCK_LABEL_61;
+            if(false)
+                break MISSING_BLOCK_LABEL_67;
+            break MISSING_BLOCK_LABEL_65;
+            if(true)
+                break MISSING_BLOCK_LABEL_67;
+            return true;
+            return false;
+        }
+
+        public static ImplicitAnyVal. MODULE$;
+
+        static 
+        {
+            new ImplicitAnyVal.();
+        }
+
+        public ImplicitAnyVal.()
+        {
+            MODULE$ = this;
+        }
+    }
+
+    public static final class ImplicitInlineAnyVal
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            .MODULE.;
+            Option option = oa();
+            JVM INSTR ifnonnull 13;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_11;
+_L2:
+            break MISSING_BLOCK_LABEL_13;
+            throw null;
+            return option.isDefined();
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(oa());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(oa(), x$1);
+        }
+
+        private final Option oa;
+
+        public ImplicitInlineAnyVal(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+    public static class ImplicitInlineAnyVal.
+    {
+
+        public final boolean bar$extension(Option $this)
+        {
+            return $this.isDefined();
+        }
+
+        public final int hashCode$extension(Option $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(Option $this, Object x$1)
+        {
+            Option option;
+            boolean flag;
+            if(x$1 instanceof ImplicitInlineAnyVal)
+                flag = true;
+            else
+                flag = false;
+            if(!flag)
+                break MISSING_BLOCK_LABEL_67;
+            option = x$1 != null ? ((ImplicitInlineAnyVal)x$1).oa() : null;
+            $this;
+            if($this != null)
+                break MISSING_BLOCK_LABEL_49;
+            JVM INSTR pop ;
+            if(option != null)
+                break MISSING_BLOCK_LABEL_61;
+            break MISSING_BLOCK_LABEL_57;
+            option;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_57;
+_L2:
+            break MISSING_BLOCK_LABEL_61;
+            if(false)
+                break MISSING_BLOCK_LABEL_67;
+            break MISSING_BLOCK_LABEL_65;
+            if(true)
+                break MISSING_BLOCK_LABEL_67;
+            return true;
+            return false;
+        }
+
+        public static ImplicitInlineAnyVal. MODULE$;
+
+        static 
+        {
+            new ImplicitInlineAnyVal.();
+        }
+
+        public ImplicitInlineAnyVal.()
+        {
+            MODULE$ = this;
+        }
+    }
+
+    public static final class ImplicitStandard
+    {
+
+        public Option oa()
+        {
+            return oa;
+        }
+
+        public boolean bar()
+        {
+            return oa().isDefined();
+        }
+
+        private final Option oa;
+
+        public ImplicitStandard(Option oa)
+        {
+            this.oa = oa;
+            super();
+        }
+    }
+
+
+    public static Option toInlineAnyVal(Option option)
+    {
+        return implicitFunctions$.MODULE$.toInlineAnyVal(option);
+    }
+
+    public static Option toAnyVal(Option option)
+    {
+        return implicitFunctions$.MODULE$.toAnyVal(option);
+    }
+
+    public static ImplicitStandard toStandard(Option option)
+    {
+        return implicitFunctions$.MODULE$.toStandard(option);
+    }
+}

--- a/jad_scala_2_12_1/implicits$.java
+++ b/jad_scala_2_12_1/implicits$.java
@@ -1,0 +1,29 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.concurrent.duration.FiniteDuration;
+
+public final class implicits$
+{
+
+    public FiniteDuration LilaPimpedFiniteDuration(FiniteDuration self)
+    {
+        return self;
+    }
+
+    private implicits$()
+    {
+        MODULE$ = this;
+    }
+
+    public static implicits$ MODULE$;
+
+    static 
+    {
+        new implicits$();
+    }
+}

--- a/jad_scala_2_12_1/implicits.java
+++ b/jad_scala_2_12_1/implicits.java
@@ -1,0 +1,113 @@
+// Decompiled by Jad v1.5.8g. Copyright 2001 Pavel Kouznetsov.
+// Jad home page: http://www.kpdus.com/jad.html
+// Decompiler options: packimports(3) 
+// Source File Name:   DurationConvertTest.scala
+
+package org.openjdk.jmh.samples;
+
+import scala.concurrent.duration.FiniteDuration;
+
+// Referenced classes of package org.openjdk.jmh.samples:
+//            implicits$
+
+public final class implicits
+{
+    public static final class LilaPimpedFiniteDuration
+    {
+
+        public FiniteDuration self()
+        {
+            return self;
+        }
+
+        public long toHundredths()
+        {
+            return .MODULE..extension(self());
+        }
+
+        public int hashCode()
+        {
+            return .MODULE..extension(self());
+        }
+
+        public boolean equals(Object x$1)
+        {
+            return .MODULE..extension(self(), x$1);
+        }
+
+        private final FiniteDuration self;
+
+        public LilaPimpedFiniteDuration(FiniteDuration self)
+        {
+            this.self = self;
+            super();
+        }
+    }
+
+    public static class LilaPimpedFiniteDuration.
+    {
+
+        public final long toHundredths$extension(FiniteDuration $this)
+        {
+            return $this.toMillis() / 10L;
+        }
+
+        public final int hashCode$extension(FiniteDuration $this)
+        {
+            return $this.hashCode();
+        }
+
+        public final boolean equals$extension(FiniteDuration $this, Object x$1)
+        {
+            FiniteDuration finiteduration;
+            boolean flag;
+            if(x$1 instanceof LilaPimpedFiniteDuration)
+                flag = true;
+            else
+                flag = false;
+            if(!flag)
+                break MISSING_BLOCK_LABEL_67;
+            finiteduration = x$1 != null ? ((LilaPimpedFiniteDuration)x$1).self() : null;
+            $this;
+            if($this != null)
+                break MISSING_BLOCK_LABEL_49;
+            JVM INSTR pop ;
+            if(finiteduration != null)
+                break MISSING_BLOCK_LABEL_61;
+            break MISSING_BLOCK_LABEL_57;
+            finiteduration;
+            equals();
+            JVM INSTR ifeq 61;
+               goto _L1 _L2
+_L1:
+            break MISSING_BLOCK_LABEL_57;
+_L2:
+            break MISSING_BLOCK_LABEL_61;
+            if(false)
+                break MISSING_BLOCK_LABEL_67;
+            break MISSING_BLOCK_LABEL_65;
+            if(true)
+                break MISSING_BLOCK_LABEL_67;
+            return true;
+            return false;
+        }
+
+        public static LilaPimpedFiniteDuration. MODULE$;
+
+        static 
+        {
+            new LilaPimpedFiniteDuration.();
+        }
+
+        public LilaPimpedFiniteDuration.()
+        {
+            MODULE$ = this;
+        }
+    }
+
+
+    public static FiniteDuration LilaPimpedFiniteDuration(FiniteDuration finiteduration)
+    {
+        return implicits$.MODULE$.LilaPimpedFiniteDuration(finiteduration);
+    }
+}

--- a/src/main/scala/ImplicitClassTest.scala
+++ b/src/main/scala/ImplicitClassTest.scala
@@ -6,23 +6,23 @@ import java.util.concurrent.TimeUnit
 
 object implicitClasses {
 
-  implicit final class ImplicitStandard[A](val oa: Option[A]) { def bar = oa.isDefined }
-  implicit final class ImplicitAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
-  @inline implicit final class ImplicitInlineBothAnyVal[A](val oa: Option[A]) extends AnyVal { @inline def bar = oa.isDefined }
-  implicit final class ImplicitInlineFunAnyVal[A](val oa: Option[A]) extends AnyVal { @inline def bar = oa.isDefined }
-  @inline implicit final class ImplicitInlineClassAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
+  implicit final class ImplicitStandard[A](val i: Int) { def bar = i + 2 }
+  implicit final class ImplicitAnyVal[A](val i: Int) extends AnyVal { def bar = i + 2 }
+  @inline implicit final class ImplicitInlineBothAnyVal[A](val i: Int) extends AnyVal { @inline def bar = i + 2 }
+  implicit final class ImplicitInlineFunAnyVal[A](val i: Int) extends AnyVal { @inline def bar = i + 2 }
+  @inline implicit final class ImplicitInlineClassAnyVal[A](val i: Int) extends AnyVal { def bar = i + 2 }
 
 }
 
 object implicitFunctions {
 
-  final class ImplicitStandard[A](val oa: Option[A]) { def bar = oa.isDefined }
-  final class ImplicitAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
-  final class ImplicitInlineAnyVal[A](val oa: Option[A]) extends AnyVal { @inline def bar = oa.isDefined }
+  final class ImplicitStandard[A](val i: Int) { def bar = i + 2 }
+  final class ImplicitAnyVal[A](val i: Int) extends AnyVal { def bar = i + 2 }
+  final class ImplicitInlineAnyVal[A](val i: Int) extends AnyVal { @inline def bar = i + 2 }
 
-  implicit def toStandard[A](oa: Option[A]) = new ImplicitStandard(oa)
-  implicit def toAnyVal[A](oa: Option[A]) = new ImplicitAnyVal(oa)
-  @inline implicit def toInlineAnyVal[A](oa: Option[A]) = new ImplicitInlineAnyVal(oa)
+  implicit def toStandard[A](i: Int) = new ImplicitStandard(i)
+  implicit def toAnyVal[A](i: Int) = new ImplicitAnyVal(i)
+  @inline implicit def toInlineAnyVal[A](i: Int) = new ImplicitInlineAnyVal(i)
 }
 
 @State(Scope.Thread)
@@ -31,7 +31,7 @@ object implicitFunctions {
 class ImplicitClassTest {
 
 
-  val option = Option(42)
+  val option: Int = 42
 
   @Benchmark
   def testClassStandard = {
@@ -82,5 +82,5 @@ class ImplicitClassTest {
   }
 
   @Benchmark
-  def baseline = option.isDefined
+  def baseline = option + 2
 }

--- a/src/main/scala/ImplicitClassTest.scala
+++ b/src/main/scala/ImplicitClassTest.scala
@@ -8,7 +8,9 @@ object implicitClasses {
 
   implicit final class ImplicitStandard[A](val oa: Option[A]) { def bar = oa.isDefined }
   implicit final class ImplicitAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
-  @inline implicit final class ImplicitInlineAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
+  @inline implicit final class ImplicitInlineBothAnyVal[A](val oa: Option[A]) extends AnyVal { @inline def bar = oa.isDefined }
+  implicit final class ImplicitInlineFunAnyVal[A](val oa: Option[A]) extends AnyVal { @inline def bar = oa.isDefined }
+  @inline implicit final class ImplicitInlineClassAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
 
 }
 
@@ -16,7 +18,7 @@ object implicitFunctions {
 
   final class ImplicitStandard[A](val oa: Option[A]) { def bar = oa.isDefined }
   final class ImplicitAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
-  @inline final class ImplicitInlineAnyVal[A](val oa: Option[A]) extends AnyVal { def bar = oa.isDefined }
+  final class ImplicitInlineAnyVal[A](val oa: Option[A]) extends AnyVal { @inline def bar = oa.isDefined }
 
   implicit def toStandard[A](oa: Option[A]) = new ImplicitStandard(oa)
   implicit def toAnyVal[A](oa: Option[A]) = new ImplicitAnyVal(oa)
@@ -44,8 +46,20 @@ class ImplicitClassTest {
   }
 
   @Benchmark
-  def testClassInlineAnyVal = {
-    import implicitClasses.ImplicitAnyVal
+  def testClassInlineBothAnyVal = {
+    import implicitClasses.ImplicitInlineBothAnyVal
+    option.bar
+  }
+
+  @Benchmark
+  def testClassImplicitInlineFunAnyVal = {
+    import implicitClasses.ImplicitInlineFunAnyVal
+    option.bar
+  }
+
+  @Benchmark
+  def testClassImplicitInlineClassAnyVal = {
+    import implicitClasses.ImplicitInlineClassAnyVal
     option.bar
   }
 
@@ -66,4 +80,7 @@ class ImplicitClassTest {
     import implicitFunctions.toInlineAnyVal
     option.bar
   }
+
+  @Benchmark
+  def baseline = option.isDefined
 }


### PR DESCRIPTION
Add -optimise flag.

Doesn't look like AnyVal or @inline actually affects perf.  But it does generate different code (see InlineClassTest.java)

`jmh:run -t1 -f 1 -wi 5 -i 5 ImplicitClassTest`

scala 2.11.8
```
baseline                            avgt    5  3.196 ± 0.218  ns/op
testClassAnyVal                     avgt    5  3.159 ± 0.303  ns/op
testClassImplicitInlineClassAnyVal  avgt    5  3.270 ± 0.138  ns/op
testClassImplicitInlineFunAnyVal    avgt    5  3.362 ± 0.150  ns/op
testClassInlineBothAnyVal           avgt    5  3.239 ± 0.054  ns/op
testClassStandard                   avgt    5  3.193 ± 0.283  ns/op
testFunctionAnyVal                  avgt    5  3.164 ± 0.143  ns/op
testFunctionInlineAnyVal            avgt    5  3.262 ± 0.051  ns/op
testFunctionStandard                avgt    5  3.355 ± 0.283  ns/op
```

scala 2.12.1
```
baseline                            avgt    5  3.213 ± 0.125  ns/op
testClassAnyVal                     avgt    5  3.817 ± 0.310  ns/op
testClassImplicitInlineClassAnyVal  avgt    5  3.853 ± 0.235  ns/op
testClassImplicitInlineFunAnyVal    avgt    5  3.869 ± 0.187  ns/op
testClassInlineBothAnyVal           avgt    5  3.782 ± 0.259  ns/op
testClassStandard                   avgt    5  3.633 ± 0.261  ns/op
testFunctionAnyVal                  avgt    5  3.860 ± 0.217  ns/op
testFunctionInlineAnyVal            avgt    5  3.853 ± 0.264  ns/op
testFunctionStandard                avgt    5  3.597 ± 0.067  ns/op
```