### PR TITLE
Test list match performance

### DIFF
--- a/src/main/scala/ListMatcherTest.scala
+++ b/src/main/scala/ListMatcherTest.scala
@@ -1,0 +1,29 @@
+package org.openjdk.jmh.samples
+
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class ListMatcherTest {
+
+  val ls = (0 to 4) map { i => (1 to i).toList } toList
+
+  @Benchmark
+  def matchCons = ls collect {
+    case x :: y :: _ => true
+    case _ => false
+  }
+
+  @Benchmark
+  def matchVars = ls collect {
+    case List(x, y, _*) => true
+    case _ => false
+  }
+
+  @Benchmark
+  def sizeBase = ls map { _.size >= 2 }
+}


### PR DESCRIPTION
> jmh:run -t1 -f 1 -wi 5 -i 10 ListMatcherTest

matchCons   33.412 ± 1.174  ns/op
matchVars   39.543 ± 0.427  ns/op
sizeBase    50.325 ± 1.127  ns/op