### PR TITLE
RegexTests

### DIFF
--- a/src/main/scala/RegexTests.scala
+++ b/src/main/scala/RegexTests.scala
@@ -1,0 +1,140 @@
+package org.openjdk.jmh.samples
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.util.matching.Regex
+
+final class ornicarRegexWrapper(private val r: Regex) extends AnyVal {
+
+  def find(s: String): Boolean =
+    r.pattern.matcher(s).find
+
+  def matches(s: String): Boolean =
+    r.pattern.matcher(s).matches
+}
+
+trait RegexI {
+  @inline implicit final def toOrnicarRegex(r: Regex) = new ornicarRegexWrapper(r)
+}
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+class RegexTests extends RegexI {
+  val unanchored = """\w+\d""".r
+  val unanchoredPoss = """\w++\d""".r
+  val anchoredPoss = """^\w++\d$""".r
+  val anchored = """^\w+\d$""".r
+
+  val l100NoMatch = "abcde" * 20
+  val l100 = l100NoMatch + "0"
+  val l1k = "abcde" * 200 + "0"
+
+
+  val anchoredGroup = """^.*(\w).*$""".r
+  val unanchoredGroup = """.*(\w).*""".r
+  val rawGroup = """(\w)""".r
+  val rawUnanchoredGroup = """(\w)""".r.unanchored
+
+  val a = "a"
+  val aPad = ("!" * 100) + "a" + ("!" * 100)
+  val noA = "!" * 200
+
+
+  @inline private def regM(r: Regex, s: String) = r.pattern.matcher(s).matches
+  @inline private def regF(r: Regex, s: String) = r.pattern.matcher(s).find
+
+  @Benchmark
+  def sMatchUnanchored = regM(unanchored, l100)
+
+  @Benchmark
+  def sMatchUnanchoredPoss = regM(unanchoredPoss, l100)
+
+  @Benchmark
+  def sMatchAnchored = regM(anchored, l100)
+
+  @Benchmark
+  def sMatchAnchoredPoss = regM(anchoredPoss, l100)
+
+  @Benchmark
+  def lMatchUnanchored = regM(unanchored, l1k)
+
+  @Benchmark
+  def lMatchUnanchoredPoss = regM(unanchoredPoss, l1k)
+
+  @Benchmark
+  def lMatchAnchored = regM(anchored, l1k)
+
+  @Benchmark
+  def lMatchAnchoredPoss = regM(anchoredPoss, l1k)
+
+  @Benchmark
+  def sNoMatchUnanchored = regM(unanchored, l100NoMatch)
+
+  @Benchmark
+  def sNoMatchUnanchoredPoss = regM(unanchoredPoss, l100NoMatch)
+
+  @Benchmark
+  def sNoMatchAnchored = regM(anchored, l100NoMatch)
+
+  @Benchmark
+  def sNoMatchAnchoredPoss = regM(anchoredPoss, l100NoMatch)
+
+  @Benchmark
+  def cGroupAnchored = regM(anchoredGroup, a)
+
+  @Benchmark
+  def cGroupUnanchored = regM(unanchoredGroup, a)
+
+  @Benchmark
+  def cGroupRawFind = regF(rawGroup, a)
+
+  @Benchmark
+  def cGroupRawFindImplicit = rawGroup.find(a)
+
+  @Benchmark
+  def cGroupUnanchoredClassFind = regF(rawUnanchoredGroup, a)
+
+  @Benchmark
+  def cGroupUnanchoredClassFindImplicit = rawUnanchoredGroup.find(a)
+
+  @Benchmark
+  def pGroupAnchored = regM(anchoredGroup, aPad)
+
+  @Benchmark
+  def pGroupUnanchored = regM(unanchoredGroup, aPad)
+
+  @Benchmark
+  def pGroupRawFind = regF(rawGroup, aPad)
+
+  @Benchmark
+  def pGroupUnanchoredClassFind = regF(rawUnanchoredGroup, aPad)
+
+  @Benchmark
+  def noAGroupAnchored = regM(anchoredGroup, noA)
+
+  @Benchmark
+  def noAGroupUnanchored = regM(unanchoredGroup, noA)
+
+  @Benchmark
+  def noAGroupRawFind = regF(rawGroup, noA)
+
+  @Benchmark
+  def noAGroupUnanchoredClassFind = regF(rawUnanchoredGroup, noA)
+
+  @Benchmark
+  def pMatcher = aPad match {
+    case unanchoredGroup(x) => x
+  }
+
+  @Benchmark
+  def pMatcherUnanchored = aPad match {
+    case rawUnanchoredGroup(x) => x
+  }
+
+  @Benchmark
+  def pMatcherUnanchoredIgnoreVars = aPad match {
+    case rawUnanchoredGroup(_*) => "y"
+  }
+}

--- a/src/main/scala/StringTests.scala
+++ b/src/main/scala/StringTests.scala
@@ -1,0 +1,20 @@
+package org.openjdk.jmh.samples
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class StringTests {
+
+  @Benchmark
+  def stringContains = "foobar".contains("a")
+
+  @Benchmark
+  def charContains = "foobar".contains('a')
+
+  @Benchmark
+  def charIndexOf = "foobar".indexOf('a') >= 0
+}


### PR DESCRIPTION
Conclusions:
- Ornicar implicits are fast and should be preferred
- `'^.*(X).*$'` should be switched to unanchored find
- Possessives slightly slower for short strings, but faster
  overall, use these.
- Unnecessary anchors (`^$`) with match slows regex slightly
- r.unanchored case match is 5x slower than direct find,
  but better than the anchored version.

```
sbt:lila-jmh-benchmarks> jmh:run -t1 -f 1 -wi 10 -i 10 RegexTests
sNoMatchAnchored                   0.521 ± 0.010  us/op
sNoMatchAnchoredPoss               0.318 ± 0.006  us/op
sNoMatchUnanchored                 0.564 ± 0.011  us/op
sNoMatchUnanchoredPoss             0.296 ± 0.006  us/op

sMatchAnchored                     0.542 ± 0.013  us/op
sMatchAnchoredPoss                 0.327 ± 0.006  us/op
sMatchUnanchored                   0.334 ± 0.010  us/op
sMatchUnanchoredPoss               0.298 ± 0.006  us/op

lMatchAnchored                     6.290 ± 0.164  us/op
lMatchAnchoredPoss                 1.898 ± 0.055  us/op
lMatchUnanchored                   2.399 ± 0.045  us/op
lMatchUnanchoredPoss               1.916 ± 0.082  us/op

cGroupAnchored                     0.104 ± 0.003  us/op
cGroupRawFind                      0.079 ± 0.002  us/op
cGroupRawFindImplicit              0.064 ± 0.001  us/op
cGroupUnanchored                   0.095 ± 0.003  us/op
cGroupUnanchoredClassFind          0.076 ± 0.002  us/op
cGroupUnanchoredClassFindImplicit  0.067 ± 0.003  us/op

noAGroupAnchored                   0.891 ± 0.013  us/op
noAGroupRawFind                    0.378 ± 0.007  us/op
noAGroupUnanchored                 0.872 ± 0.020  us/op
noAGroupUnanchoredClassFind        0.382 ± 0.013  us/op

padGroupAnchored                     1.530 ± 0.020  us/op
padGroupRawFind                      0.249 ± 0.012  us/op
padGroupUnanchored                   1.582 ± 0.070  us/op
padGroupUnanchoredClassFind          0.239 ± 0.011  us/op

pMatcher                           1.674 ± 0.039  us/op
pMatcherUnanchored                 1.081 ± 0.030  us/op
pMatcherUnanchoredIgnoreVars       1.065 ± 0.034  us/op
```