### PR TITLE
Attempt to add Atomic benchmarks.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := """lila-jmh-benchmarks"""
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.9",


### PR DESCRIPTION
This benchmark is fatally flawed because it's measuring the
rate of pushing messages onto the queue, instead of the
throughput of processed messages, and is probably causing
very large queue sizes as well.