### PR TITLE
Add ArrayDeque filter test

### DIFF
--- a/src/main/scala/ArrayDequeTest.scala
+++ b/src/main/scala/ArrayDequeTest.scala
@@ -1,0 +1,50 @@
+package org.openjdk.jmh.samples
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import java.util.ArrayDeque
+import scala.collection.JavaConverters._
+
+case class SocketVersion(value: Int) extends AnyVal with Ordered[SocketVersion] {
+  def compare(other: SocketVersion) = value compare other.value
+  def inc = SocketVersion(value + 1)
+}
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class ArrayDequeTest {
+
+  private[this] final val deque = new ArrayDeque[SocketVersion]()
+  for (i <- 1 to 50) deque.add(SocketVersion(i))
+
+  private[this] final val list = deque.asScala.toList.reverse
+
+  private[this] final val v = SocketVersion(40)
+
+  @Benchmark
+  def testDrop = deque.asScala.dropWhile(_ <= v).toList
+
+  @Benchmark
+  def testReverse = {
+    var fe: List[SocketVersion] = Nil
+    for (e <- deque.descendingIterator.asScala.takeWhile(_ > v))
+      fe = e :: fe
+    fe
+  }
+
+  @Benchmark
+  def testSlice = {
+    var fe: List[SocketVersion] = Nil
+    val it = deque.descendingIterator
+    var cnt = 10
+    while (it.hasNext && cnt > 0) {
+      fe = it.next :: fe
+      cnt -= 1
+    }
+  }
+  
+  @Benchmark
+  def testListLegacy = list.takeWhile(_ > v).reverse
+}


### PR DESCRIPTION
```
Benchmark         Score    Error  Units
testDrop        994.729 ± 19.682  ns/op
testReverse     313.043 ±  9.225  ns/op
testSlice       108.466 ±  1.827  ns/op
testListLegacy  118.992 ±  2.936  ns/op
```
hmmm 