### PR TITLE
More benchmarks for socket

### DIFF
--- a/src/main/scala/ArrayDequeTest.scala
+++ b/src/main/scala/ArrayDequeTest.scala
@@ -11,11 +11,13 @@ case class SocketVersion(value: Int) extends AnyVal with Ordered[SocketVersion] 
   def inc = SocketVersion(value + 1)
 }
 
+case class VersionedEvent(version: SocketVersion, date: Int) {}
+
+
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 class ArrayDequeTest {
-
   private[this] final val deque = new ArrayDeque[SocketVersion]()
   for (i <- 1 to 50) deque.add(SocketVersion(i))
 
@@ -35,6 +37,18 @@ class ArrayDequeTest {
   }
 
   @Benchmark
+  def testWhileReverse = {
+    var fe: List[SocketVersion] = Nil
+    var e = null.asInstanceOf[SocketVersion]
+    val it = deque.descendingIterator
+    while (it.hasNext && {
+      e = it.next
+      e > v
+    }) fe = e :: fe
+    fe
+  }
+
+  @Benchmark
   def testSlice = {
     var fe: List[SocketVersion] = Nil
     val it = deque.descendingIterator
@@ -44,7 +58,69 @@ class ArrayDequeTest {
       cnt -= 1
     }
   }
-  
+
   @Benchmark
   def testListLegacy = list.takeWhile(_ > v).reverse
+}
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class ArrayDequeAddTest {
+  private[this] var deque = new ArrayDeque[VersionedEvent]()
+  for (i <- 1 to 50) deque.add(VersionedEvent(SocketVersion(i), i))
+  private[this] final val dequeClone = deque.clone()
+  @Setup(Level.Invocation)
+  def setUp() = {
+    deque = dequeClone.clone()
+  }
+
+  private[this] final val list = deque.asScala.toList.reverse
+
+  val newEvents = (51 to 55).map(i => VersionedEvent(SocketVersion(i), i)).toList
+
+  @Benchmark
+  def testAddEventsLegacy = {
+    (slideEvents(list), newEvents.reverse)
+  }
+
+
+  private def slideEvents(history: List[VersionedEvent]) = {
+    val expiration: Int = -1
+    var nb = 0
+    newEvents ::: history.takeWhile { e =>
+      nb += 1
+      nb <= 25 && e.date > expiration
+    }
+  }
+
+  @Benchmark
+  def testAddEventsDeque = {
+    removeTail(25)
+    pruneEvents(-1)
+    val veBuff = List.newBuilder[VersionedEvent]
+    newEvents.foreach { e =>
+      veBuff += e
+      deque.addLast(e)
+    }
+    (veBuff.result, deque)
+  }
+
+  private def removeTail(maxSize: Int) = {
+    if (maxSize <= 0) deque.clear()
+    else {
+      var toRemove = deque.size() - maxSize
+      while (toRemove > 0) {
+        deque.pollFirst
+        toRemove -= 1
+      }
+    }
+  }
+
+  private def pruneEvents(minDate: Int) = {
+    while ({
+      val e = deque.peekFirst
+      (e ne null) && e.date < minDate
+    }) deque.pollFirst
+  }
 }


### PR DESCRIPTION
- 'addEvent' benchmark, which is expected to be
  the most common call (grafana coming soon)
  The arrayDeque is much faster than legacy.
- Add an impl for getEventsSince arraydeque
  (testWhileReverse). This performs as well as
  the legacy code (testListLegacy)

```
Benchmark                                Score    Error  Units
ArrayDequeAddTest.testAddEventsDeque   162.808 ±  4.383  ns/op
ArrayDequeAddTest.testAddEventsLegacy  333.977 ±  5.740  ns/op
ArrayDequeTest.testDrop                966.867 ± 16.162  ns/op
ArrayDequeTest.testListLegacy          119.983 ±  2.083  ns/op
ArrayDequeTest.testReverse             351.275 ±  7.668  ns/op
ArrayDequeTest.testSlice                99.584 ±  5.557  ns/op
ArrayDequeTest.testWhileReverse        123.148 ±  5.192  ns/op
```